### PR TITLE
Rewrite documentation site and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,112 +3,127 @@
 [![PyPI Version](https://img.shields.io/pypi/v/cherimoya.svg)](https://pypi.org/project/cherimoya/)
 ![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/jmschrei/cherimoya/blob/main/LICENSE)
+[![Documentation](https://img.shields.io/badge/docs-readthedocs-blue.svg)](https://cherimoya.readthedocs.io)
 
 
 > [!IMPORTANT]
-> Cherimoya is still under active development and may change in ways that are not back compatible. Please make note of the version you are using in case you need to return to it in the future.
+> Cherimoya is under active development and may introduce breaking changes between versions. Pin the version you train with if you need to reload checkpoints later.
 
-Cherimoya is a lightweight genomic sequence-to-function (S2F) model for predicting genomic modalities such as transcription factor binding, chromatin accessibility, and transcription initiation. It builds on concepts that were first introduced by BPNet and ChromBPNet while introducing architectural, algorithmic, and systems-level improvements that improve training stability, efficiency, and predictive performance. Despite needing significantly fewer parameters than other architectures, Cherimoya achieves strong predictive performance across a range of tasks and runs ~5-15x faster when measured on an H200 GPU. 
+Cherimoya is a compact deep learning model for predicting genomic profile data — transcription factor binding, chromatin accessibility, transcription initiation — directly from DNA sequence. It pairs a lightweight ConvNeXt-style backbone with custom Triton GPU kernels for both training and inference, and ships with an end-to-end CLI that takes BAM files through peak calling, training, attribution, and motif discovery in a single command. The default 9-layer model is **~340K parameters** and runs a full forward in **well under a millisecond per batch on an H200**, while delivering strong predictive performance across the assays we've benchmarked.
 
 <img src="https://github.com/jmschrei/cherimoya/blob/main/imgs/cheri-model.png">
 
-The secret to Cherimoya's success is a new Cheri Block, which adapts the ConvNeXT block to the domain of noisy high-throughput genomics experiments. This block is comprised of a dilated depth-wise convolution, a layer norm, a projection into a higher-dimensional space, a GeLU non-linearity, a projection back into the original dimensionality, and a residual connection scaled by a small fixed constant. Conceptually, this means that the blocks first aggregate information spatially but independently for each feature/channel (the depth-wise convolution) and then aggregate information across features but independently for each position (the two projections). The dilated depth-wise convolution and the layer norm have been fused into an efficient custom GPU kernel that is ~2-3x faster than the native PyTorch implementation.
+### Design highlights
 
-<img src="https://github.com/jmschrei/cherimoya/blob/main/imgs/cheri-block.png">
+The backbone is built from **Cheri Blocks** — each a depthwise dilated convolution followed by per-example layer normalization and a channel-mixing MLP, fused into custom Triton kernels so spatial and channel information are aggregated cheaply and at separate stages of each block. Training uses a tuned dual optimizer — **Muon** for projection weights, **AdamW** for everything else — with hyperparameters discovered via large-scale sweeps. The profile and counts losses are combined via **Kendall-Gal uncertainty weighting** with two learnable scalars, replacing the usual fixed loss weight with one the model balances on its own. An **exponential moving average** of the parameters is maintained during training and used at evaluation, smoothing both the validation curve and the final predictions. Several **stability-first** choices keep deep stacks well-behaved: a small fixed residual scale at initialization, no biases in the blocks, no weight decay, and a 5-epoch warmup before cosine decay. Both the architecture and the training recipe were arrived at via agent-driven exploration of the design space. See [the architecture docs](https://cherimoya.readthedocs.io/en/latest/architecture.html) for the full story.
 
 ### Installation
 
 ```bash
-pip install cherimoya
+pip install cherimoya          # or: uv pip install cherimoya
 ```
 
-Or, using [uv](https://docs.astral.sh/uv/):
-
-```bash
-uv pip install cherimoya
-```
-
-To install from source:
+From source:
 
 ```bash
 git clone https://github.com/jmschrei/cherimoya.git
-cd cherimoya
-pip install -e .    # or: uv pip install -e .
+cd cherimoya && pip install -e .
 ```
 
-### Key Features
+GPU acceleration requires Triton and a CUDA-capable device; a pure-PyTorch CPU fallback is available for everything except the inference megakernel. See [the installation guide](https://cherimoya.readthedocs.io/en/latest/installation.html) for Triton compatibility notes.
 
-*Lightweight Architecture*: Cherimoya employs a compact convolutional backbone that substantially reduces parameter count while also slightly increasing predictive accuracy. This design enables efficient training, large-scale hyperparameter exploration, interactive usage via browsers, and usage of dozens or hundreds of such models simultaneously in complex design settings.
+### What you can do with Cherimoya
 
-*Stable training*: Several design choices were made to improve the stability of model training, including the use of layer norm in each layer, a small fixed scalar on each residual connection (configurable via the `residual_scale` argument on both `CheriBlock` and `Cherimoya`, default 0.15) that keeps the path close to the identity mapping at initialization, a cosine decay learning rate scheduler with a long warmup (5 epochs by default), removing all bias terms in the Cheri blocks, and, somewhat counterintuitively, removing weight decay from the optimizers.
+- Train a sequence-to-function model on ChIP-seq, ATAC-seq, DNase-seq, PRO-seq, or any signal that can be expressed as a stranded or unstranded coverage track.
+- Compute per-base attribution scores via *in silico* saturation mutagenesis.
+- Call seqlets and discover *de novo* motifs with TF-MoDISco.
+- Annotate seqlets against a known motif database via tomtom-lite.
+- Marginalize the contribution of inserted motifs in counterfactual sequence designs.
+- Score variants by predicting their effects on the underlying profile and counts.
+- Reproduce a training run bit-for-bit from a seed — the peak/negative sampler is a pure function of `(seed, epoch, index)`, and `num_workers > 1` is purely a speed optimization that produces the same batch sequence as `num_workers = 1`.
+- Stream remote BAM, BED, and FASTA inputs directly without downloading them first.
 
-*Automatic Loss Weight Balancing*: Profile and count losses are combined using learned weighting parameters rather than fixed hyperparameters. This approach replaces the heuristic developed for BPNet and ChromBPNet models and enables the models to scale to larger contexts and across modalities automatically, while also improving gradient stability across datasets with varying signal-to-noise characteristics.
+### The Cheri Block
 
-*Muon Optimizer*: Cherimoya uses the Muon optimizer when training the projection layers, and the AdamW optimizer for all other layers and terms. This has significantly accelerated training by reducing the number of epochs needed while modestly improving performance.
+<img src="https://github.com/jmschrei/cherimoya/blob/main/imgs/cheri-block.png">
 
-*Model Compilation*: Because of the architectural decisions made in the Cheri block, many operations can be automatically fused together in neat ways when using `torch.compile` and so this has been built-in to the forward pass. This seems to offer a ~50-75% speed improvement. Although this compilation needs to only be done once and can be then re-used across models and sessions, it may need to be redone each time the batch size has changed, e.g., for the last batch being processed.
+Each block performs a 3-tap dilated depthwise convolution, a per-example layer normalization, a linear expansion to `expansion × n_filters` channels, a GELU non-linearity, a contraction back to `n_filters` channels, and a residual connection scaled by a small fixed constant (`residual_scale`, default `0.15`). The convolution and normalization are fused into a custom Triton kernel; under `torch.no_grad()` the entire block (including the MLP) collapses into a second fused megakernel for inference. The default 9-layer model uses dilations `1, 2, 4, ..., 256`, giving a receptive field of 1115 bp and a 2114 → 1000 bp input/output by default. See [the architecture docs](https://cherimoya.readthedocs.io/en/latest/architecture.html) for receptive field math, kernel internals, and the rationale for each design choice.
 
-*Mixed Precision*: When data is of reasonable depth, Cherimoya models are best trained using mixed precision, which can offer a ~2x speed improvement (sometimes more when also compiling the model). However, using mixed precision can hurt performance when the data is very low quality or low read depth, such as for TF ChIP-seq experiments or pseudobulks for rare cell types. We recommend using `float32` precision for BPNet-style models as a starting point unless you have particularly high-quality data.
+### Performance
 
-*Deterministic Sampling*: The peak/negative sampler in `PeakGenerator` is a pure function of `(random_state, epoch, idx)`, so every peak appears exactly once per epoch and two runs with the same seed produce bit-identical training data. `num_workers > 1` is purely a speed optimization — it produces the **same** sequence of batches as `num_workers = 1`, just faster.
+| Path | Single block (N=16, L=1024, C=96) | Full Cherimoya (N=4, L=2114, default) |
+|---|---|---|
+| CPU (pure PyTorch) | 4.71 ms | 21.92 ms |
+| GPU, grad-enabled (training fwd) | 0.101 ms | 1.106 ms |
+| GPU, no_grad (inference megakernel) | **0.064 ms** | **0.583 ms** |
 
+All three paths agree on the model output to within ~1e-5 max-abs, so existing trained checkpoints produce numerically equivalent predictions through every path. The forward-only megakernel is automatically dispatched when gradients aren't needed; training is unaffected. CPU inference is comfortable for development and one-off evaluation on a laptop — only training and high-throughput inference benefit from a GPU. See [the benchmarks page](https://cherimoya.readthedocs.io/en/latest/benchmarks.html) for the full sweep across batch sizes and model widths.
 
-### Saving and Loading Models
+### End-to-end CLI pipeline
 
-Models are saved as a dictionary containing the constructor arguments and a state dict, rather than a pickled module. This format is robust to source-layout changes and is safe to load with PyTorch's `weights_only=True` setting:
+<img src="https://github.com/jmschrei/cherimoya/blob/main/imgs/pipeline.png" width=70%>
+
+The CLI strings the full pipeline — peak calling, signal extraction, training, attribution, seqlet calling, motif discovery — into a single reproducible run. Each step is parameterized through a JSON file, which serves both as a runtime config and a permanent record of what was run. The user-supplied JSON is merged with sensible defaults, so practical configs are short.
+
+**Step 1: generate a pipeline JSON from raw data pointers.** Provide a reference genome, one or more signal files, optional controls, a BED of positive loci, and a motif database. For stranded ChIP-seq:
+
+```bash
+cherimoya pipeline-json \
+    -s hg38.fa -p peaks.bed.gz \
+    -i input1.bam -i input2.bam \
+    -c control1.bam -c control2.bam \
+    -m JASPAR_2024.meme -n my_experiment -o pipeline.json
+```
+
+For unstranded paired-end ATAC-seq with the standard +4/−4 fragment shift:
+
+```bash
+cherimoya pipeline-json \
+    -s hg38.fa -p peaks.bed.gz \
+    -i fragments.bam -m JASPAR_2024.meme \
+    -n atac_experiment -o pipeline.json \
+    -ps 4 -ns -4 -u -f -pe
+```
+
+Any input path can be remote (S3, HTTPS, etc.); the pipeline streams reads through `bam2bw` directly.
+
+**Step 2: edit the JSON if you want to override defaults** — model width, training/validation chromosomes, seqlet p-value threshold, MoDISco settings, anything. Then run:
+
+```bash
+cherimoya pipeline -p pipeline.json
+```
+
+This calls peaks with MACS3, samples GC-matched negatives, trains a Cherimoya model, computes attributions via saturation mutagenesis, calls seqlets, annotates them with tomtom-lite, and runs TF-MoDISco. The outputs land in the working directory: a `.torch` model checkpoint and training log, per-track bigWigs, a saturation-mutagenesis attribution array (`.npz`), a seqlet table with tomtom-lite annotations, and a TF-MoDISco results H5. Each sub-step writes its own JSON snapshot so individual stages can be re-run in isolation with the `negatives`, `fit`, `evaluate`, `attribute`, `marginalize`, or `seqlets` subcommands. The `batch` subcommand parallelizes a pipeline across multiple datasets. See [the CLI reference](https://cherimoya.readthedocs.io/en/latest/cli.html) for the full command list and JSON schema.
+
+### Python API and saving/loading
+
+For programmatic use, the three public symbols are `Cherimoya` (the model), `CheriBlock` (the building block), and `EMA` (the parameter exponential-moving-average wrapper used during training):
 
 ```python
 from cherimoya import Cherimoya
 
-model = Cherimoya(n_filters=96, n_layers=9, n_outputs=2)
-# ... train ...
+model = Cherimoya(n_filters=96, n_layers=9, n_outputs=1).cuda()
+y_profile, y_counts = model(X)              # X: (N, 4, L) one-hot DNA
+```
+
+Models are saved as a config + state_dict bundle, not a pickled module. This format is robust to source-layout changes and safe to load with `weights_only=True`:
+
+```python
 model.save("my_model.torch")
-
-# Load on CPU (default)
-model = Cherimoya.load("my_model.torch")
-
-# Or load directly onto a GPU
+model = Cherimoya.load("my_model.torch")              # CPU by default
 model = Cherimoya.load("my_model.torch", device="cuda")
 ```
 
-The CLI commands (`evaluate`, `attribute`, `marginalize`) and `model.fit()` use this format internally. Older checkpoints saved with `torch.save(model, ...)` are not compatible with `Cherimoya.load` and should be retrained.
+Older checkpoints saved with `torch.save(model, ...)` are not compatible with `Cherimoya.load` and must be retrained. The CLI subcommands and `model.fit(...)` use this format internally. See [the Python API docs](https://cherimoya.readthedocs.io/en/latest/api/model.html) for the full `fit()` and `predict()` signatures.
 
-### End-to-End Pipeline
+### Documentation
 
-<img src="https://github.com/jmschrei/cherimoya/blob/main/imgs/pipeline.png" width=70%>
+Full documentation, including tutorials, architecture details, and API reference, is at [cherimoya.readthedocs.io](https://cherimoya.readthedocs.io). The [changelog](https://cherimoya.readthedocs.io/en/latest/CHANGELOG.html) tracks user-visible changes between versions.
 
-Cherimoya provides an integrated command-line pipeline that allows you to go directly from mapped reads, to model training and evaluation, to analysis results. This pipeline improves reproducibility by being self-documenting on the parameter settings for each step, and dramatically reduces the overhead associated with managing seperate tooling for each stage. Specifically, it includes:
+### Citation
 
-- Conversion from BAM/SAM/fragment files to (un)/stranded bigWig(s) using bam2bw
-- Peak calling using MACS3
-- Calling of GC-matched negatives
-- Model training and evaluation
-- Attribution scores using *in silico* saturation mutagenesis
-- Seqlet calling and annotation using tomtom-lite
-- De novo motif discovery using TF-MoDISco
+If you use Cherimoya in published work, please cite the repository. A formal preprint is forthcoming.
 
-A multi-step pipeline like this has many hyperparameters that can be customized at each step (e.g., number of filters in the model, number of seqlets to use for TF-MoDISco) and requires pointers to several input and output files. Rather than using a giant command-line call, Cherimoya uses JSONs to manage each step of the pipeline. An advantage of using JSONs is that they create a permanent record of the exact command that was run. Although there are many hyperparameters, the user-provided JSONs can be quite small in practice because they are internally merged with the default parameters for each step. The fastest way to begin this process is through the `pipeline-json` command, which takes in pointers to your data files and flags describing the data and produces a valid JSON for the pipeline process. These data files usually include a reference genome, some number of input (and optionally control) BAM/SAM/tsv/tsv.gz files (the `-i` and `-c` arguments can be repeated) a BED file of positive loci, and a MEME formatted motif database used for evaluation of the model.
+### License
 
-For example, if you are working with ChIP-seq data that is stranded:
-
-```
-cherimoya pipeline-json -s hg38.fa -p peaks.bed.gz -i input1.bam -i input2.bam -c control1.bam -c control2.bam -n test -o pipeline.json -m JASPAR_2024.meme
-```
-
-If you are working with ATAC-seq data, which is unstranded and comes in the form of paired-end fragmnents that need to be shifted +4/-4 (as they do in the ChromBPNet work) you can use the following:
-
-```
-cherimoya pipeline-json -s hg38.fa -p peaks.bed.gz -i input1.bam -i input2.bam -n atac-test -o atac-pipeline.json -m JASPAR_2024.meme -ps 4 -ns -4 -u -f -pe
-```
-
-Note that any of these data pointers can point to remote files. This will stream the data through bam2bw and read the peak files remotely. Processing speed will then depend on the speed of your internet connection and whether the hosting site throttles your connection.
-
-The resulting JSON stored at `pipeline.json` or `atac-pipeline.json` can then be executed using the `pipeline` command. These commands are separated because, although the first command produces a valid JSON that the second command can immediately use, one may wish to modify some of the many parameters in the JSON. These parameters include the number of filters and layers in the model, the training and validation chromosomes, and the p-value threshold for calling seqlets. The defaults for most of these steps seem reasonable in practice, but there is immense flexibility there, e.g., the ability to train the model using a reference genome and then make predictions or attributions on synthetic sequences or the reference genome from another species. In this manner, the JSON serves as documentation for the experiments that have been performed.
-
-```
-cherimoya pipeline -p pipeline.json
-```
-
-When running the pipeline, a JSON is produced for each one of the steps (except for running TF-MoDISco and annotating the seqlets, which uses `ttl`). Each of these JSONs can be run by itself using the appropriate built-in command. Because some of the values in the JSONs for these steps are set programmatically when running the file pipeline, e.g., the filenames to read in and save to, being able to inspect every one of the JSONs can be handy for debugging.
-  
-
+MIT. See [`LICENSE`](https://github.com/jmschrei/cherimoya/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Cherimoya is a compact deep learning model for predicting genomic profile data �
 
 ### Design highlights
 
-The backbone is built from **Cheri Blocks** — each a depthwise dilated convolution followed by per-example layer normalization and a channel-mixing MLP, fused into custom Triton kernels so spatial and channel information are aggregated cheaply and at separate stages of each block. Training uses a tuned dual optimizer — **Muon** for projection weights, **AdamW** for everything else — with hyperparameters discovered via large-scale sweeps. The profile and counts losses are combined via **Kendall-Gal uncertainty weighting** with two learnable scalars, replacing the usual fixed loss weight with one the model balances on its own. An **exponential moving average** of the parameters is maintained during training and used at evaluation, smoothing both the validation curve and the final predictions. Several **stability-first** choices keep deep stacks well-behaved: a small fixed residual scale at initialization, no biases in the blocks, no weight decay, and a 5-epoch warmup before cosine decay. Both the architecture and the training recipe were arrived at via agent-driven exploration of the design space. See [the architecture docs](https://cherimoya.readthedocs.io/en/latest/architecture.html) for the full story.
+The backbone is built from **Cheri Blocks** — each a depthwise dilated convolution followed by per-example layer normalization and a channel-mixing MLP, fused into custom Triton kernels so spatial and channel information are aggregated cheaply and at separate stages of each block. Training uses a tuned dual optimizer — **Muon** for projection weights, **AdamW** for everything else — with hyperparameters discovered via large-scale sweeps. The profile and counts losses are combined via **Kendall-Gal uncertainty weighting** with two learnable scalars, replacing the usual fixed loss weight with one the model balances on its own. An **exponential moving average** of the parameters is maintained during training and used at evaluation, smoothing both the validation curve and the final predictions. Several **stability-first** choices keep deep stacks well-behaved: a small fixed residual scale at initialization, no biases in the blocks, minimal weight decay on the Muon-routed projection weights, and a 5-epoch warmup before cosine decay. Both the architecture and the training recipe were arrived at via agent-driven exploration of the design space. See [the architecture docs](https://cherimoya.readthedocs.io/en/latest/architecture.html) for the full story.
 
 ### Installation
 
@@ -34,12 +34,12 @@ GPU acceleration requires Triton and a CUDA-capable device; a pure-PyTorch CPU f
 
 ### What you can do with Cherimoya
 
-- Train a sequence-to-function model on ChIP-seq, ATAC-seq, DNase-seq, PRO-seq, or any signal that can be expressed as a stranded or unstranded coverage track.
-- Compute per-base attribution scores via *in silico* saturation mutagenesis.
-- Call seqlets and discover *de novo* motifs with TF-MoDISco.
-- Annotate seqlets against a known motif database via tomtom-lite.
-- Marginalize the contribution of inserted motifs in counterfactual sequence designs.
-- Score variants by predicting their effects on the underlying profile and counts.
+- Train a sequence-to-function model on [TF ChIP-seq](https://cherimoya.readthedocs.io/en/latest/recipes/chipseq_tf.html), [ATAC-seq](https://cherimoya.readthedocs.io/en/latest/recipes/atacseq.html), [DNase-seq](https://cherimoya.readthedocs.io/en/latest/recipes/dnaseq.html), or any signal that can be expressed as a stranded or unstranded coverage track.
+- Compute per-base attribution scores via [*in silico* saturation mutagenesis](https://cherimoya.readthedocs.io/en/latest/tutorials/attribution.html).
+- Call seqlets and discover *de novo* motifs with [TF-MoDISco](https://cherimoya.readthedocs.io/en/latest/tutorials/attribution.html#tf-modisco-motif-discovery).
+- Annotate seqlets against a known motif database via [tomtom-lite](https://cherimoya.readthedocs.io/en/latest/tutorials/attribution.html#tomtom-lite-annotation).
+- [Marginalize](https://cherimoya.readthedocs.io/en/latest/tutorials/variant_effect.html#motif-marginalization-cli) the contribution of inserted motifs in counterfactual sequence designs.
+- [Score variants](https://cherimoya.readthedocs.io/en/latest/tutorials/variant_effect.html) by predicting their effects on the underlying profile and counts.
 - Reproduce a training run bit-for-bit from a seed — the peak/negative sampler is a pure function of `(seed, epoch, index)`, and `num_workers > 1` is purely a speed optimization that produces the same batch sequence as `num_workers = 1`.
 - Stream remote BAM, BED, and FASTA inputs directly without downloading them first.
 
@@ -57,7 +57,7 @@ Each block performs a 3-tap dilated depthwise convolution, a per-example layer n
 | GPU, grad-enabled (training fwd) | 0.101 ms | 1.106 ms |
 | GPU, no_grad (inference megakernel) | **0.064 ms** | **0.583 ms** |
 
-All three paths agree on the model output to within ~1e-5 max-abs, so existing trained checkpoints produce numerically equivalent predictions through every path. The forward-only megakernel is automatically dispatched when gradients aren't needed; training is unaffected. CPU inference is comfortable for development and one-off evaluation on a laptop — only training and high-throughput inference benefit from a GPU. See [the benchmarks page](https://cherimoya.readthedocs.io/en/latest/benchmarks.html) for the full sweep across batch sizes and model widths.
+All three paths agree on the model output to within ~1e-5 max-abs, so existing trained checkpoints produce numerically equivalent predictions through every path. The forward-only megakernel is automatically dispatched when gradients aren't needed; training is unaffected. CPU inference is comfortable for development and one-off evaluation on a laptop — only training and high-throughput inference benefit from a GPU. See [the benchmarks page](https://cherimoya.readthedocs.io/en/latest/benchmarks.html) for measurement methodology and the script you can run on your own hardware.
 
 ### End-to-end CLI pipeline
 
@@ -65,21 +65,23 @@ All three paths agree on the model output to within ~1e-5 max-abs, so existing t
 
 The CLI strings the full pipeline — peak calling, signal extraction, training, attribution, seqlet calling, motif discovery — into a single reproducible run. Each step is parameterized through a JSON file, which serves both as a runtime config and a permanent record of what was run. The user-supplied JSON is merged with sensible defaults, so practical configs are short.
 
-**Step 1: generate a pipeline JSON from raw data pointers.** Provide a reference genome, one or more signal files, optional controls, a BED of positive loci, and a motif database. For stranded ChIP-seq:
+**Step 1: generate a pipeline JSON from raw data pointers.** Provide a reference genome, one or more signal files, optional controls, a BED of positive loci, and a motif database. For stranded ChIP-seq with input controls (full recipe [here](https://cherimoya.readthedocs.io/en/latest/recipes/chipseq_tf.html)):
 
 ```bash
 cherimoya pipeline-json \
-    -s hg38.fa -p peaks.bed.gz \
-    -i input1.bam -i input2.bam \
-    -c control1.bam -c control2.bam \
+    -s hg38.fa -p peaks.narrowPeak \
+    -i chipseq_rep1.bam -i chipseq_rep2.bam \
+    -c input_rep1.bam -c input_rep2.bam \
     -m JASPAR_2024.meme -n my_experiment -o pipeline.json
 ```
 
-For unstranded paired-end ATAC-seq with the standard +4/−4 fragment shift:
+Note: `-i` is the ChIP signal (IP reads) and `-c` is the unenriched-DNA input control.
+
+For unstranded paired-end ATAC-seq with the standard +4/−4 fragment shift (full recipe [here](https://cherimoya.readthedocs.io/en/latest/recipes/atacseq.html)):
 
 ```bash
 cherimoya pipeline-json \
-    -s hg38.fa -p peaks.bed.gz \
+    -s hg38.fa -p peaks.narrowPeak \
     -i fragments.bam -m JASPAR_2024.meme \
     -n atac_experiment -o pipeline.json \
     -ps 4 -ns -4 -u -f -pe
@@ -97,7 +99,7 @@ This calls peaks with MACS3, samples GC-matched negatives, trains a Cherimoya mo
 
 ### Python API and saving/loading
 
-For programmatic use, the three public symbols are `Cherimoya` (the model), `CheriBlock` (the building block), and `EMA` (the parameter exponential-moving-average wrapper used during training):
+For programmatic use, the three public symbols are `Cherimoya` (the model), `CheriBlock` (the building block), and `EMA` (the parameter exponential-moving-average wrapper used during training). See the [Python API tutorial](https://cherimoya.readthedocs.io/en/latest/tutorials/python_api.html) for an end-to-end training walkthrough:
 
 ```python
 from cherimoya import Cherimoya
@@ -114,11 +116,11 @@ model = Cherimoya.load("my_model.torch")              # CPU by default
 model = Cherimoya.load("my_model.torch", device="cuda")
 ```
 
-Older checkpoints saved with `torch.save(model, ...)` are not compatible with `Cherimoya.load` and must be retrained. The CLI subcommands and `model.fit(...)` use this format internally. See [the Python API docs](https://cherimoya.readthedocs.io/en/latest/api/model.html) for the full `fit()` and `predict()` signatures.
+Older checkpoints saved with `torch.save(model, ...)` are not compatible with `Cherimoya.load` and must be retrained. The CLI subcommands and `model.fit(...)` use this format internally. See [the save/load guide](https://cherimoya.readthedocs.io/en/latest/tutorials/save_load.html) for full semantics (including that the saved weights are the EMA snapshot) and [the Python API reference](https://cherimoya.readthedocs.io/en/latest/api/model.html) for the full `fit()` and `predict()` signatures.
 
 ### Documentation
 
-Full documentation, including tutorials, architecture details, and API reference, is at [cherimoya.readthedocs.io](https://cherimoya.readthedocs.io). The [changelog](https://cherimoya.readthedocs.io/en/latest/CHANGELOG.html) tracks user-visible changes between versions.
+Full documentation, including tutorials, architecture details, and API reference, is at [cherimoya.readthedocs.io](https://cherimoya.readthedocs.io). New to the terminology? See the [glossary](https://cherimoya.readthedocs.io/en/latest/glossary.html). Hitting an error? See the [troubleshooting page](https://cherimoya.readthedocs.io/en/latest/troubleshooting.html). The [changelog](https://cherimoya.readthedocs.io/en/latest/CHANGELOG.html) tracks user-visible changes between versions.
 
 ### Citation
 

--- a/cherimoya/performance.py
+++ b/cherimoya/performance.py
@@ -316,23 +316,25 @@ def calculate_performance_measures(logps, true_counts, pred_log_counts,
 	its function, but this function provides a wrapper around running any
 	number of them. The measures one can choose are:
 
-		Profile Performance Measures
-		- "profile_mnll": the multinomial log-likelihood of the observed profile given
-			the predicted logits
-		- "profile_jsd": the Jensen-Shannon divergence between the observed profile and
-			the predicted probabilities
-		- "profile_pearson": the Pearson correlation between the observed profile and
-			the predicted probabilities
-		- "profile_spearman": the Spearman correlation between the observed profiles
-			and the predicted probabilities
+	Profile performance measures:
 
-		Count Performance Measures
-		- "count_pearson": the Pearson correlation between the observed log counts and
-			the predicted log counts
-		- "count_spearman": the Spearman correlation between the observed log counts
-			and the predicted log counts
-		- "count_mse": the mean-squared error between the observed log counts and the
-			predicted log counts.
+	- ``profile_mnll``: the multinomial log-likelihood of the observed
+	  profile given the predicted logits.
+	- ``profile_jsd``: the Jensen-Shannon divergence between the observed
+	  profile and the predicted probabilities.
+	- ``profile_pearson``: the Pearson correlation between the observed
+	  profile and the predicted probabilities.
+	- ``profile_spearman``: the Spearman correlation between the observed
+	  profiles and the predicted probabilities.
+
+	Count performance measures:
+
+	- ``count_pearson``: the Pearson correlation between the observed log
+	  counts and the predicted log counts.
+	- ``count_spearman``: the Spearman correlation between the observed
+	  log counts and the predicted log counts.
+	- ``count_mse``: the mean-squared error between the observed log
+	  counts and the predicted log counts.
 
 	Optionally, one can choose to smooth the *observed* data before calculating
 	the profile correlations and JSD. It is important to note that this smoothing

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -7,36 +7,63 @@ v0.1.0
 Model
 ~~~~~
 
-* Replaced the learnable channel-wise scaling with a fixed constant.
-* Added an exponential moving average (EMA) of model weights during training.
+* Added a fully fused **forward-only inference megakernel** for the
+  Cheri Block: conv + norm + MLP + residual in two GPU passes, with
+  bf16 dot products. Used automatically when
+  ``torch.is_grad_enabled()`` is ``False`` and the MLP hidden width is
+  a multiple of 16, with automatic fallback to the training Triton
+  path otherwise. Numerically equivalent to the training path within
+  ~1e-5 max-abs at unit-scale outputs, and roughly 1.9× faster than
+  the training-fwd path on H200 at the default model size.
+* The training Triton kernel and the CPU fallback are unchanged.
+  Existing trained checkpoints are bit-compatible.
+* Replaced the learnable channel-wise scaling with a fixed
+  ``residual_scale`` constant (default 0.15).
+* Added an exponential moving average (EMA) of model weights during
+  training; validation and saved checkpoints use the EMA-applied
+  weights.
 * Changed the final profile convolution to ``kernel_width=1``.
 * Set the default model size to 96 filters.
-* Tuned the Muon and AdamW learning rates and weight decay values for
-  improved convergence.
-* Best-model selection now monitors the validation profile loss rather than
-  the total validation loss.
+* Tuned the Muon and AdamW learning rates and weight decay values
+  for improved convergence (Muon ``lr=0.025, wd=0.01``; AdamW
+  ``lr=0.004, wd=0.2``).
+* Best-model selection now monitors the validation count Pearson
+  correlation rather than the total validation loss.
+
+API
+~~~
+
+* ``Cherimoya.save`` / ``Cherimoya.load`` checkpoints now use a
+  config + state_dict payload that is robust to source-layout
+  changes and loads with PyTorch's ``weights_only=True``. Older
+  pickle-based checkpoints (``torch.save(model, ...)``) are not
+  compatible and must be migrated or retrained.
+* :class:`cherimoya.cherimoya.EMA` is now a public top-level symbol
+  alongside :class:`cherimoya.Cherimoya` and
+  :class:`cherimoya.CheriBlock`.
 
 Training
 ~~~~~~~~
 
-* Default ``max_jitter`` for fitting lowered from 500 to 50 (applied across
-  the package's fitting defaults).
+* Default ``max_jitter`` for fitting lowered from 500 to 50.
 
 Packaging and tooling
 ~~~~~~~~~~~~~~~~~~~~~
 
-* Migrated from ``setup.py`` to ``pyproject.toml`` with ``uv`` support.
-* Refactored the CLI from a monolithic script into the ``cherimoya_cli``
-  modular package.
-* Raised the minimum Python version to 3.10 and minimum PyTorch to 2.9.
-* Added ``macs3``, ``bam2bw``, ``bpnet-lite``, ``triton``, and ``joblib``
-  as dependencies.
+* Migrated from ``setup.py`` to ``pyproject.toml`` with ``uv``
+  support.
+* Refactored the CLI from a monolithic script into the
+  ``cherimoya_cli`` modular package.
+* Raised the minimum Python version to 3.10 and minimum PyTorch
+  to 2.9.
+* Added ``macs3``, ``bam2bw``, ``bpnet-lite``, ``triton``, and
+  ``joblib`` as dependencies.
 * Added a Sphinx documentation site hosted on Read the Docs.
 
 v0.0.1
 ------
 
-* Initial release of the Cherimoya model and pipeline. 
-* Includes the `CheriBlock` architecture and custom kernels.
+* Initial release of the Cherimoya model and pipeline.
+* Includes the ``CheriBlock`` architecture and custom kernels.
 * Features a dual-optimizer training strategy (AdamW + Muon).
 * Implements a full end-to-end processing and modeling pipeline.

--- a/docs/api/cheri.rst
+++ b/docs/api/cheri.rst
@@ -1,0 +1,142 @@
+cherimoya.cheri
+===============
+
+.. module:: cherimoya.cheri
+
+The Cheri Block — Cherimoya's adaptation of the ConvNeXt block — plus
+the fused dilated-conv-plus-layer-norm dispatcher used inside it. For
+the high-level model see :doc:`model`; for the architectural story
+behind these primitives see :doc:`../architecture`.
+
+
+CheriBlock
+----------
+
+.. autoclass:: CheriBlock
+   :members: forward
+   :undoc-members:
+   :show-inheritance:
+
+   .. rubric:: Constructor
+
+   .. automethod:: __init__
+
+
+fused_dilated_conv_norm
+-----------------------
+
+.. autofunction:: fused_dilated_conv_norm
+
+Public dispatcher used inside :class:`CheriBlock`. Routes to the
+training Triton kernel on CUDA when gradients are enabled, otherwise
+to the pure-PyTorch fallback (``_cheri_conv_norm_cpu``). Numerically
+equivalent up to floating-point error.
+
+
+FusedDilatedConvNormFunc
+------------------------
+
+.. autoclass:: FusedDilatedConvNormFunc
+   :members: forward, backward
+   :undoc-members:
+
+A custom ``torch.autograd.Function`` that fuses the 3-tap dilated
+depthwise convolution and per-example layer normalization. User code
+interacts with it through :func:`fused_dilated_conv_norm` and
+:class:`CheriBlock`.
+
+
+Forward kernels
+~~~~~~~~~~~~~~~
+
+The forward pass runs three Triton kernels in sequence:
+
+* ``_fwd_stats_kernel`` — runs over ``(N, num_chunks_of_L)``
+  blocks. For each block it loads the three dilated taps, computes
+  the convolved output and stores it into the output buffer ``y``,
+  and atomically accumulates per-example ``sum`` and ``sq_sum`` of
+  the convolved values into ``(N,)`` float32 buffers.
+* ``_fwd_finalize_kernel`` — runs over ``(N,)``: turns the per-example
+  ``sum``/``sq_sum`` into ``mean``/``rstd`` with the
+  ``eps=1e-3`` numerical stability constant.
+* ``_fwd_apply_kernel`` — runs over ``(N, num_chunks_of_L)``: loads
+  ``y`` in-place, subtracts the mean, multiplies by ``rstd``, writes
+  back the normalized value.
+
+Layer-norm statistics are always accumulated and stored in fp32 even
+when ``y`` is bf16, which keeps the normalization numerically robust
+under autocast.
+
+
+Backward kernels
+~~~~~~~~~~~~~~~~
+
+The backward pass also runs three Triton kernels in sequence and
+**recomputes** the convolved output during the backward pass rather
+than caching it from the forward — trading a small amount of FLOPS
+for the activation memory of an extra ``(N, L, C)`` tensor:
+
+* ``_bwd_stats_kernel`` — recomputes the conv output ``conv = x0*w0
+  + x1*w1 + x2*w2``, stores it into a scratch buffer, and atomically
+  accumulates two per-example reductions: ``sum_dy`` and
+  ``sum_dy_xhat`` (where ``xhat = (conv - mean) * rstd``). These are
+  the two scalars the layer-norm backward needs.
+* ``_bwd_apply_kernel`` — uses ``sum_dy`` and ``sum_dy_xhat`` to
+  compute ``d_conv = (rstd/count) * (count*dy - sum_dy - xhat *
+  sum_dy_xhat)`` for every position, and accumulates the depthwise
+  weight gradient ``dw`` by computing ``d_conv * x{0,1,2}`` and
+  reducing along the length axis. Per-block ``dw`` partials are
+  written into a ``(N * num_chunks, 3 * C)`` buffer; the final
+  ``dw`` is the sum over all partials (handled outside the kernel).
+* ``_bwd_dx_kernel`` — applies the dilated transpose convolution to
+  ``d_conv`` to produce ``dx``: at each position ``p``, ``dx[p] =
+  d_conv[p] * w1 + d_conv[p + d] * w0 + d_conv[p - d] * w2`` (the
+  three terms each masked at the sequence ends).
+
+The first call on a given ``(C, L)`` shape triggers Triton autotune,
+and the user-visible *gradient* output from that very first call is
+contaminated by atomic-add residue from the benchmarking trials.
+Subsequent calls use the locked-in best config and agree with CPU
+autograd at fp32 precision. The test suite warms up the kernel
+before any gradient is read; training is unaffected in practice
+because step 2 onward is clean.
+
+
+Autotune configuration space
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Both the forward stats kernel and the two backward kernels are
+autotuned over the cartesian product of:
+
+* ``num_warps``: 4, 8, 16
+* ``num_stages``: 2, 3, 4, 5
+
+with the autotune key set to ``(C, L)``. ``BLOCK_C`` is set to
+``triton.next_power_of_2(C)`` per call (so it adapts to the
+actual channel width); ``BLOCK_L`` is fixed at 64.
+
+The inference megakernel autotunes its own normalization-plus-MLP
+kernel over the same warp/stage grid, with an additional
+``BLOCK_HK`` (hidden width tile) constraint applied via the
+``prune_configs_by={'early_config_prune': ...}`` callback to keep
+the hidden tile a divisor of ``expansion * n_filters``.
+
+
+Inference megakernel
+--------------------
+
+When ``torch.is_grad_enabled()`` is ``False`` and the MLP hidden
+width is a multiple of 16, the Cheri Block dispatches to a fused
+inference megakernel that performs conv + norm + MLP + residual in
+two GPU passes rather than four separate ops. The implementation
+lives under the ``_fwd_inf_`` prefix in
+``cherimoya/cheri.py``. It is not part of the public API, but the
+behavior is observable:
+
+* The bf16 cast of the linear weights is keyed by ``(id, _version)``
+  on both parameters, so any in-place update (including
+  ``load_state_dict``) invalidates the cache automatically.
+* The cache lives on the ``CheriBlock`` instance
+  (``CheriBlock._w_cache``) and is **not** part of the state dict.
+* The path produces outputs that differ from the training Triton
+  path by at most ~1e-5 max-abs at unit-scale outputs.

--- a/docs/api/io.rst
+++ b/docs/api/io.rst
@@ -1,7 +1,12 @@
-Data Loading
+cherimoya.io
 ============
 
 .. module:: cherimoya.io
+
+Data loading utilities for training Cherimoya. The dataset is the
+peak/negative mixture sampler; the function-style entry point
+:func:`PeakGenerator` is the typical way to build a training
+``DataLoader``.
 
 
 PeakGenerator
@@ -21,3 +26,9 @@ PeakNegativeSampler
    .. rubric:: Constructor
 
    .. automethod:: __init__
+
+The sampler is fully deterministic given ``random_state`` and the
+epoch number. ``__getitem__(idx)`` is a pure function of ``idx`` and
+the current epoch, so ``num_workers > 1`` yields the same batch
+sequence as ``num_workers = 1`` and two runs with the same seed
+produce bit-identical training data.

--- a/docs/api/model.rst
+++ b/docs/api/model.rst
@@ -1,13 +1,18 @@
-Model
-=====
+cherimoya.cherimoya
+===================
 
 .. module:: cherimoya.cherimoya
+
+The top-level module exposes the model and the EMA helper used during
+training. The Cheri Block, the fused conv+norm dispatcher, and the
+inference megakernel internals are in :doc:`cheri`.
+
 
 Cherimoya
 ---------
 
 .. autoclass:: Cherimoya
-   :members: forward, fit
+   :members: forward, fit, save, load
    :undoc-members:
    :show-inheritance:
 
@@ -16,24 +21,24 @@ Cherimoya
    .. automethod:: __init__
 
 
-CheriBlock
-----------
+EMA
+---
 
-.. autoclass:: CheriBlock
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-
-FusedDilatedConvNormFunc
-------------------------
-
-.. autoclass:: FusedDilatedConvNormFunc
-   :members: forward, backward
+.. autoclass:: EMA
+   :members: update, apply_shadow, restore
    :undoc-members:
 
-   A custom ``torch.autograd.Function`` that fuses the dilated depthwise
-   convolution and layer normalization into a single Triton GPU kernel.
+   .. rubric:: Constructor
 
-   This is an internal implementation detail and should not need to be called
-   directly. It is used inside :class:`CheriBlock`.
+   .. automethod:: __init__
+
+Used internally by :meth:`Cherimoya.fit`: a shadow copy of every
+floating-point parameter (decay 0.999 by default) is updated after
+every optimizer step, swapped in for validation
+(``apply_shadow``/``restore``), and applied to the saved checkpoints
+at the end of each improvement and at the very end of training.
+
+The shadow weights are kept on the same device as the model. They
+are not part of the ``state_dict`` and are not saved with
+``Cherimoya.save``; they exist only for the duration of the training
+run.

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -2,11 +2,16 @@ Architecture
 ============
 
 Cherimoya is a compact convolutional architecture for predicting genomic
-modalities from DNA sequence. It builds on the ConvNeXt design philosophy,
-adapting it to the challenges of noisy high-throughput genomics experiments.
+profile data from DNA sequence. It pairs a ConvNeXt-style backbone with
+custom Triton GPU kernels and a training recipe designed for stability
+on noisy high-throughput genomics signals.
+
+This page describes the model, the Cheri Block, the three forward
+paths, the loss design, and the training strategy. For measured
+runtimes see :doc:`benchmarks`.
 
 
-Model Overview
+Model overview
 --------------
 
 .. image:: ../imgs/cheri-model.png
@@ -15,18 +20,34 @@ Model Overview
 
 |
 
-The model consists of three stages:
+The model consists of three stages.
 
-1. **Input convolution**: A 1D convolution (kernel size 21) maps the one-hot
-   encoded DNA sequence (4 channels) into a higher-dimensional feature space.
+1. **Input stem**. A 1D convolution (``kernel_size=21``, padding 10)
+   maps the one-hot encoded DNA sequence (4 channels) into
+   ``n_filters`` channels, followed by a GELU non-linearity. Default
+   ``n_filters`` is 96.
 
-2. **Cheri Blocks**: A stack of blocks with exponentially increasing dilation
-   rates (1, 2, 4, 8, ...) that progressively expand the receptive field. The
-   default configuration uses 9 blocks with 96 filters.
+2. **Cheri-block backbone**. A stack of ``n_layers`` (default 9) Cheri
+   Blocks with exponentially increasing dilation rates ``1, 2, 4, …,
+   2^(n_layers-1)``. The blocks operate in channels-last layout
+   ``(N, L, C)`` and are the heart of the model.
 
-3. **Output heads**: Separate heads for profile prediction (a 1×1 pointwise
-   convolution) and count prediction (a linear layer over the mean-pooled
-   features).
+3. **Output heads**. A 1×1 pointwise convolution produces the profile
+   prediction over the trimmed output window. A linear layer over the
+   mean-pooled backbone features (also restricted to the trimmed output
+   window) produces the count prediction. The count head can be either a
+   single scalar per example (``single_count_output=True``, the
+   default) or one count per output track.
+
+The default 9-layer, 96-filter model has roughly 340K parameters. The
+default input window is 2114 bp and the default output window is 1000
+bp; the difference (557 bp on each side) is the ``trimming`` and equals
+``46 + sum(2**i for i in range(n_layers))`` by default. The ``46`` is
+the receptive field of the 21-bp input stem and the 1×1 profile head;
+the dilated-conv sum (``1 + 2 + 4 + … + 256 = 511`` for the default
+9-layer model) is the receptive field of the backbone itself. The
+trimming therefore matches the model's receptive field on each side,
+so every output position has full context.
 
 
 The Cheri Block
@@ -38,31 +59,33 @@ The Cheri Block
 
 |
 
-Each Cheri Block performs the following operations:
+Each Cheri Block performs the following operations on an input of shape
+``(N, L, C)``:
 
-1. **Dilated depthwise convolution** — aggregates spatial information
-   independently for each channel, with a kernel size of 3 and increasing
-   dilation rates.
+1. **3-tap dilated depthwise convolution**. Reads from positions
+   ``(i - dilation, i, i + dilation)`` for each output position ``i``,
+   with zero padding outside the sequence. One scalar weight per channel
+   per tap, so the convolution has ``3 * C`` parameters.
 
-2. **Layer normalization** — stabilizes activations. The convolution and
-   normalization are fused into a single custom Triton GPU kernel for
-   efficiency.
+2. **Per-example layer normalization**. Mean and variance are computed
+   across the full ``(L, C)`` plane for each example (i.e. one
+   normalization statistic pair per example, computed in fp32). The
+   conv and norm are fused into a single Triton kernel; see
+   :doc:`api/cheri`.
 
-3. **Expansion projection** — a linear layer projects from ``n_filters`` to
-   ``expansion × n_filters`` dimensions, where ``expansion`` is configurable
-   on both ``CheriBlock`` and ``Cherimoya``. Default is 2.
+3. **Expansion projection**. A linear layer mapping ``C →
+   expansion * C`` with no bias. ``expansion`` defaults to 2.
 
-4. **GELU activation** — the approximate ``tanh``-based variant.
+4. **GELU**. The ``tanh``-approximate variant.
 
-5. **Contraction projection** — projects from ``expansion × n_filters``
-   back to ``n_filters`` dimensions.
+5. **Contraction projection**. A linear layer mapping
+   ``expansion * C → C`` with no bias.
 
-6. **Residual connection with fixed scaling** — the MLP output is scaled
-   by a configurable fixed constant (``residual_scale``, default
-   ``0.15``) before being added back to the input. The small constant
-   keeps the residual path near-identity at initialization, which
-   stabilizes training of deep stacks. Both ``CheriBlock`` and
-   ``Cherimoya`` accept ``residual_scale`` as a constructor argument.
+6. **Residual connection with fixed scale**. The MLP output is scaled
+   by a fixed constant ``residual_scale`` (default 0.15) and added
+   back to the input. The small constant keeps the residual path
+   near-identity at initialization, which stabilizes training of deep
+   stacks.
 
 In code:
 
@@ -73,70 +96,193 @@ In code:
        X_mlp = self.linear2(self.activation(self.linear1(X_conv)))
        return X + X_mlp * self.residual_scale
 
-
-Custom Triton Kernel
---------------------
-
-The dilated depthwise convolution and layer normalization are fused into a
-custom Triton kernel (``FusedDilatedConvNormFunc``) with both forward and
-backward passes. This fusion eliminates intermediate memory allocations and
-achieves **~2–3× speedup** over the native PyTorch implementation.
-
-The kernel is autotuned across:
-
-- Number of warps: 4, 8, 16
-- Number of pipeline stages: 2, 3, 4, 5
-- Block sizes: 32, 64, 128, 256
-
-CPU and Triton-less fallback
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-When a tensor is on the CPU, or when Triton is not installed, the block
-falls back to a pure-PyTorch implementation
-(``cherimoya.cheri._cheri_conv_norm_cpu``) that produces numerically
-equivalent output up to floating-point error. The dispatcher
-(``fused_dilated_conv_norm``) chooses between the two paths automatically
-based on the input device. This means models can be constructed and run
-on machines without a GPU, which is useful for debugging, testing, and
-unit tests.
+The conv weight has shape ``(3, C)``; the linear weights have shapes
+``(expansion * C, C)`` and ``(C, expansion * C)``. None of the layers in
+a Cheri Block has a bias term.
 
 
-Loss Function Design
---------------------
+Parameter initialization
+------------------------
+
+Every weight in the model — the input stem convolution, every Cheri
+Block's depthwise conv and two linear projections, the 1×1 profile
+head, and the count-head linear layer — is initialized with
+``trunc_normal_(std=0.02)``. The biases that exist (input stem, profile
+head, count head) are zero-initialized. The Cheri Block layers
+themselves have no biases. The Kendall-Gal loss-weight scalars
+(``lw0``, ``lw1``) are initialized to 1.
+
+This small fixed init combined with the fixed ``residual_scale=0.15``
+on each Cheri Block keeps the per-block contribution to the residual
+stream small at step 0, so the loss landscape near initialization is
+close to the identity-prediction landscape rather than a noisy
+high-variance one.
+
+
+Three forward paths
+-------------------
+
+The Cheri Block has three forward implementations that produce
+numerically equivalent output, dispatched automatically per-call:
+
+* **CPU fallback** on CPU input (pure PyTorch, differentiable,
+  reference for the test suite).
+* **Training Triton kernel** on CUDA with gradients enabled
+  (``FusedDilatedConvNormFunc`` fuses conv + norm; the MLP runs as
+  standard PyTorch ops).
+* **Inference megakernel** on CUDA when ``torch.is_grad_enabled() ==
+  False`` and ``expansion * n_filters % 16 == 0`` (fuses
+  conv + norm + MLP + residual; bf16 dot products in the MLP).
+
+All three agree on the model output to ~1e-5 max-abs at unit-scale
+outputs, so existing trained checkpoints are bit-compatible across
+paths. For the kernel-level implementation, the autotune config
+space, and the inference-megakernel weight-cache details, see
+:doc:`api/cheri`.
+
+
+Customizing the backbone
+------------------------
+
+The :class:`~cherimoya.Cherimoya` model is a thin shell around a
+``torch.nn.ModuleList`` of :class:`~cherimoya.CheriBlock` instances.
+To swap the block for a different module, subclass and replace the
+``self.blocks`` list in ``__init__``:
+
+.. code-block:: python
+
+   class MyVariant(Cherimoya):
+       def __init__(self, *args, **kwargs):
+           super().__init__(*args, **kwargs)
+           self.blocks = torch.nn.ModuleList([
+               MyBlock(self.n_filters, 2 ** i)
+               for i in range(self.n_layers)
+           ])
+
+The forward pass calls each block as ``X = self.blocks[i](X)`` with
+``X`` in channels-last layout ``(N, L, C)``. The block must accept
+and return the same shape. The rest of the model (input stem, profile
+head, count head, EMA, dual-optimizer routing) is unchanged.
+
+The dual-optimizer routing rule (``ndim == 2 and "weight" in name and
+name != "linear.weight"``) is shape-based, not name-based, so any 2D
+weight inside a custom block will go to Muon automatically. Override
+this in your own training script if you want different routing.
+
+
+Loss design
+-----------
 
 Cherimoya uses a two-component loss:
 
-- **Profile loss**: Multinomial negative log-likelihood (MNLL) over the
-  base-pair resolution profile predictions.
-- **Count loss**: Mean squared error in log-space (``log1pMSE``) between
-  predicted and observed total counts.
+* **Profile loss**: Multinomial negative log-likelihood (MNLL) over the
+  base-pair resolution profile predictions, computed on the flattened
+  ``(strand × length)`` axis so a single multinomial is fit across all
+  strands.
 
-These are combined using **learned weighting parameters** (``lw0``, ``lw1``)
-rather than fixed hyperparameters:
+* **Counts loss**: ``log1pMSE`` between predicted log counts and
+  ``log(1 + total_counts)``.
+
+These are combined using **Kendall-Gal uncertainty weighting** with
+two learnable scalars ``lw0`` and ``lw1``:
 
 .. code-block:: python
 
    w0 = 1.0 / (2.0 * self.lw0 ** 2)
    w1 = 1.0 / (2.0 * self.lw1 ** 2)
    loss = w0 * profile_loss + w1 * count_loss
+   if self.lw0.requires_grad:
+       loss += (torch.log(self.lw0) ** 2 + torch.log(self.lw1) ** 2).sum()
 
-The weights are automatically frozen once their gradients become negligible,
-preventing further unnecessary updates.
+The log-squared regularizer prevents either scalar from running to
+zero. Once their gradients become negligible (``|grad(lw0)|.sum() < 1``
+at the end of an epoch), both scalars are frozen for the rest of
+training.
 
 
-Training Strategy
+Training strategy
 -----------------
 
-Cherimoya uses a **dual-optimizer** approach:
+**Dual optimizer.** Parameters are routed between two optimizers based
+on shape and naming:
 
-- **Muon optimizer** for 2D projection weights (the ``linear1`` and ``linear2``
-  layers in each Cheri Block)
-- **AdamW optimizer** for all other parameters (convolutions, biases,
-  loss-weight scalars)
+* **Muon** receives every 2D parameter whose name contains
+  ``"weight"`` and is *not* ``"linear.weight"`` (the count-head linear
+  layer). In practice this is the two dense layers inside each Cheri
+  Block.
+* **AdamW** receives everything else: the input/output convolutions,
+  the depthwise conv weight inside each Cheri Block, the count head's
+  linear layer, the bias terms, and the loss-weight scalars
+  (``lw0``, ``lw1``).
 
-Both optimizers use a **warmup + cosine decay** learning rate schedule:
+Default learning rates and weight decays:
 
-- 5 epochs of linear warmup (from 1% of the target learning rate)
-- Cosine annealing to ``1e-5`` over the remaining epochs
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20
+
+   * - Optimizer
+     - Learning rate
+     - Weight decay
+   * - Muon
+     - 0.025
+     - 0.01
+   * - AdamW
+     - 0.004
+     - 0.2
+
+**Schedule.** Both optimizers use a ``LinearLR`` warmup of 5 epochs
+(starting from 1% of the target LR) followed by a ``CosineAnnealingLR``
+decay over the remaining ``max_epochs - 5`` epochs down to ``1e-5``,
+chained with ``SequentialLR``.
+
+**EMA at evaluation.** During training the model maintains an
+:class:`~cherimoya.cherimoya.EMA` shadow of every floating-point
+parameter with decay 0.999. After each optimizer step the EMA is
+updated. At validation the shadow weights are swapped into the model
+(``apply_shadow``), validation runs, and the original weights are
+restored (``restore``). The model file saved as ``best`` and the
+``.final.torch`` checkpoint contain the EMA-applied weights.
+
+**Best-model selection.** The best checkpoint is the one with the
+highest validation count Pearson correlation. ``early_stopping``, if
+set, stops training when that count Pearson has not improved for that
+many consecutive epochs.
+
+**Reproducibility.** The peak/negative sampler
+(:class:`~cherimoya.io.PeakNegativeSampler`) is a pure function of
+``(random_state, epoch, idx)``. Two runs with the same ``random_state``
+draw the same examples in the same order, and ``num_workers > 1`` is a
+pure speed optimization — it does not change the batch sequence.
 
 
+How these choices were made
+---------------------------
+
+Both the architecture (block layout, dilation schedule, expansion
+factor, residual scale, normalization placement) and the training
+recipe (optimizer split, learning rates, weight decays, warmup
+length, EMA decay) were arrived at via large-scale, agent-driven
+exploration of the design space rather than hand tuning. The
+numbers reported on this page are the converged settings; they are
+not arbitrary defaults but the result of automated search across
+many candidate configurations.
+
+
+Stability-first defaults
+------------------------
+
+A handful of choices keep deep stacks well-behaved during training:
+
+* **Fixed residual scale** at initialization (``0.15``) keeps the
+  residual path near-identity, so the loss landscape at step 0 is
+  close to the input distribution.
+* **No biases** inside Cheri Blocks (conv, ``linear1``, ``linear2``).
+  Bias is only used in the input/output convolutions and the count
+  head.
+* **No weight decay** on Muon-routed weights at the level of the
+  optimizer's effective update (Muon uses orthogonalization, which is
+  scale-invariant; ``muon_wd=0.01`` is a small safety margin).
+* **5-epoch warmup** from 1% of the target LR before cosine decay.
+* **fp32 norm statistics** in the layer-norm step, even when the rest
+  of the forward runs in bf16.

--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -1,0 +1,70 @@
+Benchmarks
+==========
+
+This page reports measured timing and numerical agreement for the three
+forward paths of the Cheri Block. See :doc:`architecture` for the
+description of each path.
+
+Setup
+-----
+
+All numbers below were measured on a single NVIDIA H200 with PyTorch
+2.9 and Triton 3.5. CPU numbers were measured on the same host's CPU
+cores. Each measurement uses a warmup phase to lock in Triton autotune
+configurations before the timed iterations begin; reported numbers are
+the median over many iterations.
+
+The benchmark script is checked into the repository root as
+``bench_kernels.py``. It is excluded from the package install. Run it
+on your own hardware to get numbers specific to your machine.
+
+Forward timing
+--------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 30 35
+
+   * - Path
+     - Single block
+       (N=16, L=1024, C=96)
+     - Full Cherimoya
+       (N=4, L=2114, default 9-layer 96-filter)
+   * - CPU (pure PyTorch)
+     - 4.71 ms
+     - 21.92 ms
+   * - GPU, grad-enabled (training fwd)
+     - 0.101 ms
+     - 1.106 ms
+   * - GPU, ``no_grad`` (inference megakernel)
+     - **0.064 ms**
+     - **0.583 ms**
+
+The megakernel is dispatched automatically when ``torch.is_grad_enabled()``
+is ``False`` and the MLP hidden width (``expansion * n_filters``) is a
+multiple of 16. Training is unaffected.
+
+All three paths agree on the model output to ~1e-5 max-abs at
+unit-scale outputs, so trained checkpoints produce numerically
+equivalent predictions through every path. The breakdown of which
+pair agrees to fp32 precision vs. which pair differs by the bf16
+weight cast is in :doc:`architecture`.
+
+
+Caveats
+-------
+
+* The numbers above are for *forward* passes only. Training step time
+  is dominated by the backward pass and the optimizer step, neither of
+  which the megakernel touches.
+* H200-specific. On older GPUs (A100, V100) the absolute numbers
+  change, but the relative ordering CPU ≫ train-fwd > inference-fwd
+  holds.
+* CPU inference is comfortable for development and one-off evaluation
+  on a laptop; only training and high-throughput inference benefit
+  from a GPU.
+* The autotune step on the first call to any Triton kernel takes
+  significant wall time. The warmup pass in ``bench_kernels.py``
+  exists specifically to amortize this. If you call the model once
+  and observe a slow first call, that is autotune — subsequent calls
+  use the cached configuration.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,675 @@
+CLI Reference
+=============
+
+Reference for every ``cherimoya`` subcommand, every command-line flag,
+and every key of every JSON parameter file. Pulled from
+``cherimoya_cli.defaults`` and the per-subcommand ``argparse`` setup;
+update these tables when the source defaults change.
+
+For a walkthrough of how the pieces fit together see
+:doc:`tutorials/cli_pipeline`.
+
+
+Common conventions
+------------------
+
+* Every subcommand except ``pipeline-json`` and ``negatives`` is
+  driven by a JSON file passed with ``-p``. Keys missing from the JSON
+  fall back to the corresponding default in
+  ``cherimoya_cli.defaults``.
+* Most JSON schemas accept ``"skip": true`` to no-op the step. The
+  ``pipeline`` JSON accepts ``"dry_run": true`` to print/emit the
+  per-step JSONs without running any subprocess.
+* List-valued keys (``signals``, ``controls``, ``loci``, ``negatives``,
+  ``training_chroms``, ``validation_chroms``, ``chroms``) accept
+  multiple values. Single-string scalars are coerced to a one-element
+  list internally in some places.
+* Path-valued keys can be remote URLs (``http://``, ``https://``,
+  ``s3://``, ``gs://``). Remote paths are streamed by ``bam2bw`` and
+  ``tangermeme.io`` and skipped by the pre-flight existence check
+  inside ``cherimoya pipeline``.
+
+
+cherimoya pipeline-json
+-----------------------
+
+Emit a fully-populated pipeline JSON from a small number of CLI
+pointers.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 14 68
+
+   * - Flag
+     - Type
+     - Description
+   * - ``-s, --sequences``
+     - path
+     - Reference genome FASTA.
+   * - ``-i, --inputs``
+     - path (repeatable)
+     - Signal file (BAM/SAM/fragment file/bigWig). Repeat for multiple
+       replicates.
+   * - ``-c, --controls``
+     - path (repeatable)
+     - Optional control file. Repeat for multiple replicates.
+   * - ``-p, --peaks``
+     - path (repeatable)
+     - Optional BED of peak coordinates. If omitted, MACS3 calls
+       peaks.
+   * - ``-neg, --negatives``
+     - path (repeatable)
+     - Optional BED of GC-matched negatives. If omitted, the pipeline
+       samples them.
+   * - ``-n, --name``
+     - str
+     - Suffix used in intermediate filenames.
+   * - ``-u, --unstranded``
+     - flag
+     - Treat signal as unstranded (single output track).
+   * - ``-f, --fragments``
+     - flag
+     - Treat input as fragment files, not aligned reads.
+   * - ``-ps, --pos_shift``
+     - int
+     - Shift applied to + strand reads (bp). Default 0.
+   * - ``-ns, --neg_shift``
+     - int
+     - Shift applied to - strand reads (bp). Default 0.
+   * - ``-m, --motifs``
+     - path
+     - MEME-format motif database. When set, TF-MoDISco report,
+       tomtom-lite annotation, and marginalization are run.
+   * - ``-o, --output``
+     - path
+     - Output JSON path.
+   * - ``-pe, --paired_end``
+     - flag
+     - Treat input as paired-end. Affects MACS3 file format
+       (``BAMPE``) and ``bam2bw`` fragment reconstruction.
+   * - ``-sf, --scale_factor``
+     - float
+     - Multiplier on the raw read counts. Default 1 (no scaling).
+
+
+cherimoya pipeline
+------------------
+
+Run an end-to-end pipeline from a JSON file.
+
+CLI flags:
+
+* ``-p, --parameters`` (required) — path to the pipeline JSON.
+
+JSON schema (top-level keys, with defaults from
+``default_pipeline_parameters``):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - Key
+     - Default
+     - Description
+   * - ``in_window``
+     - 2114
+     - Input window size (bp).
+   * - ``out_window``
+     - 1000
+     - Output window size (bp).
+   * - ``name``
+     - ``null``
+     - Suffix for intermediate filenames; required.
+   * - ``model``
+     - ``null``
+     - Optional path to an existing ``.torch`` checkpoint. If set,
+       skip the training step and use this model for downstream
+       stages.
+   * - ``dtype``
+     - ``"float32"``
+     - Tensor dtype for inference; can be ``"bfloat16"`` etc.
+   * - ``device``
+     - ``"cuda"``
+     - Torch device for inference and training.
+   * - ``batch_size``
+     - 512
+     - Batch size for inference stages (attribution, evaluation).
+   * - ``verbose``
+     - ``true``
+     - Print per-step progress.
+   * - ``random_state``
+     - ``null``
+     - Base RNG seed for the data sampler.
+   * - ``exclusion_lists``
+     - ``null``
+     - BED file(s) of regions to exclude.
+   * - ``sequences``
+     - ``null``
+     - Reference genome FASTA. Required.
+   * - ``loci``
+     - ``null``
+     - BED of peaks. If null, MACS3 calls peaks.
+   * - ``negatives``
+     - ``null``
+     - BED of negatives. If null, GC-matched negatives are sampled.
+   * - ``signals``
+     - ``null``
+     - List of signal files (BAM or bigWig). Required.
+   * - ``controls``
+     - ``null``
+     - Optional list of control files.
+   * - ``skip``
+     - ``false``
+     - If ``true``, the whole pipeline is a no-op.
+   * - ``dry_run``
+     - ``false``
+     - If ``true``, write all per-step JSONs but do not run any
+       subprocess.
+   * - ``preprocessing_parameters``
+     - (sub-dict, below)
+     - Settings for MACS3 peak calling and ``bam2bw``.
+   * - ``fit_parameters``
+     - (sub-dict, below)
+     - Training parameters.
+   * - ``attribute_parameters``
+     - (sub-dict, below)
+     - Attribution parameters.
+   * - ``seqlet_parameters``
+     - (sub-dict, below)
+     - Seqlet calling parameters.
+   * - ``annotation_parameters``
+     - (sub-dict, below)
+     - tomtom-lite annotation parameters.
+   * - ``modisco_motifs_parameters``
+     - (sub-dict, below)
+     - TF-MoDISco motif discovery parameters.
+   * - ``modisco_report_parameters``
+     - (sub-dict, below)
+     - TF-MoDISco report parameters.
+   * - ``marginalize_parameters``
+     - (sub-dict, below)
+     - Marginalization parameters.
+
+
+preprocessing_parameters
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - Key
+     - Default
+     - Description
+   * - ``unstranded``
+     - ``false``
+     - Produce a single unstranded bigWig instead of a ``+ / -`` pair.
+   * - ``fragments``
+     - ``false``
+     - Treat input as fragment files.
+   * - ``paired_end``
+     - ``false``
+     - Treat input as paired-end; affects MACS3 format.
+   * - ``pos_shift``
+     - 0
+     - + strand shift (bp).
+   * - ``neg_shift``
+     - 0
+     - - strand shift (bp).
+   * - ``scale_factor``
+     - 1
+     - Multiplier on raw counts.
+   * - ``read_depth``
+     - ``false``
+     - Pass ``-r`` to ``bam2bw`` to scale by sequencing depth.
+   * - ``callpeaks_format``
+     - ``null``
+     - MACS3 ``-f`` value. ``null`` auto-detects from the input file
+       extension and ``paired_end`` flag.
+   * - ``callpeaks_gsize``
+     - ``"hs"``
+     - MACS3 ``-g`` value (effective genome size). Use ``"mm"`` for
+       mouse, a numeric value for other organisms.
+   * - ``callpeaks_q``
+     - 0.05
+     - MACS3 q-value cutoff.
+   * - ``verbose``
+     - ``true``
+     - Print per-step progress.
+
+
+fit_parameters
+~~~~~~~~~~~~~~
+
+These keys are merged with ``default_fit_parameters`` before training.
+Unspecified keys fall back to the fit-level defaults.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - Key
+     - Default
+     - Description
+   * - ``n_filters``
+     - 96
+     - Backbone channel width.
+   * - ``n_layers``
+     - 9
+     - Number of Cheri Blocks.
+   * - ``expansion``
+     - 2
+     - MLP expansion factor inside each Cheri Block.
+   * - ``residual_scale``
+     - 0.15
+     - Fixed residual scalar.
+   * - ``batch_size``
+     - 64
+     - Training batch size.
+   * - ``muon_lr``
+     - 0.025
+     - Muon learning rate.
+   * - ``muon_wd``
+     - 0.01
+     - Muon weight decay.
+   * - ``adam_lr``
+     - 0.004
+     - AdamW learning rate.
+   * - ``adam_wd``
+     - 0.2
+     - AdamW weight decay.
+   * - ``negative_ratio``
+     - 0.1
+     - Negatives per peak per epoch.
+   * - ``num_workers``
+     - 1
+     - Async prefetch workers for the data loader.
+   * - ``single_count_output``
+     - ``true``
+     - One scalar count per example vs. one per output track.
+   * - ``early_stopping``
+     - 15
+     - Stop after N consecutive epochs with no validation count
+       Pearson improvement.
+   * - ``max_jitter``
+     - 50
+     - Maximum jitter (bp) for peak centers at training time.
+   * - ``reverse_complement``
+     - ``true``
+     - Augment training with reverse complements.
+   * - ``reverse_complement_average``
+     - ``false``
+     - Evaluation-time RC averaging.
+   * - ``max_epochs``
+     - 50
+     - Maximum training epochs.
+   * - ``training_chroms``
+     - hg38 default (chr2, chr4, chr5, chr7, chr9-22, chrX, chrY)
+     - Chromosomes used for training.
+   * - ``validation_chroms``
+     - ``["chr8", "chr20"]``
+     - Held-out chromosomes for validation.
+   * - ``in_window`` / ``out_window``
+     - 2114 / 1000
+     - Input / output window sizes (bp).
+   * - ``summits``
+     - ``false``
+     - Center loci on narrowPeak summit column.
+   * - ``dtype``
+     - ``"float32"``
+     - Training dtype (``"bfloat16"`` enables autocast).
+   * - ``device``
+     - ``"cuda"``
+     - Training device.
+   * - ``random_state``
+     - ``null``
+     - Base RNG seed.
+
+
+attribute_parameters
+~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 25 45
+
+   * - Key
+     - Default
+     - Description
+   * - ``batch_size``
+     - 512
+     - Inference batch size.
+   * - ``chroms``
+     - training + validation chroms
+     - Chromosomes to attribute.
+   * - ``output``
+     - ``"counts"``
+     - Attribute to counts or profile (``"profile"``).
+   * - ``ohe_filename``
+     - ``"attributions.ohe.npz"``
+     - Output: one-hot encoded inputs.
+   * - ``attr_filename``
+     - ``"attributions.attr.npz"``
+     - Output: per-base hypothetical importance.
+   * - ``idx_filename``
+     - ``"attributions.idx.npy"``
+     - Output: boolean mask back to the original loci list.
+   * - ``dtype`` / ``device``
+     - ``"float32"`` / ``"cuda"``
+     - Inference dtype and device.
+
+
+seqlet_parameters
+~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - Key
+     - Default
+     - Description
+   * - ``threshold``
+     - 0.01
+     - Recursive seqlet p-value threshold.
+   * - ``min_seqlet_len`` / ``max_seqlet_len``
+     - 4 / 25
+     - Minimum and maximum seqlet length (bp).
+   * - ``additional_flanks``
+     - 3
+     - Flanking bases retained on each side.
+   * - ``in_window``
+     - 2114
+     - Input window used during attribution; matches
+       ``fit_parameters.in_window``.
+   * - ``ohe_filename`` / ``attr_filename`` / ``idx_filename``
+     - inherit from ``attribute_parameters``
+     - Inputs from the attribute step.
+   * - ``output_filename``
+     - ``"seqlets.bed"``
+     - Output BED.
+
+
+annotation_parameters
+~~~~~~~~~~~~~~~~~~~~~
+
+tomtom-lite (``ttl``) annotation runs only when ``motifs`` is set on
+the top-level JSON.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - Key
+     - Default
+     - Description
+   * - ``motifs``
+     - inherit
+     - MEME-format motif database.
+   * - ``sequences``
+     - inherit
+     - Reference genome FASTA.
+   * - ``seqlet_filename``
+     - inherit
+     - Seqlet BED from the seqlets step.
+   * - ``n_score_bins``
+     - 100
+     - ``ttl -s``.
+   * - ``n_median_bins``
+     - 1000
+     - ``ttl -m``.
+   * - ``n_target_bins``
+     - 100
+     - ``ttl -a``.
+   * - ``n_cache``
+     - 250
+     - ``ttl -c``.
+   * - ``reverse_complement``
+     - ``true``
+     - Scan motifs in both orientations.
+   * - ``n_jobs``
+     - -1
+     - Parallel workers; -1 uses all cores.
+   * - ``output_filename``
+     - ``"seqlets_annotated.bed"``
+     - Output BED.
+
+
+modisco_motifs_parameters / modisco_report_parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - Key
+     - Default
+     - Description
+   * - ``n_seqlets``
+     - 100000
+     - Number of seqlets passed to ``modisco motifs``.
+   * - ``output_filename``
+     - ``"{name}_modisco_results.h5"``
+     - HDF5 output of ``modisco motifs``.
+   * - ``output_folder``
+     - ``"{name}_modisco/"``
+     - Directory output of ``modisco report``.
+   * - ``motifs``
+     - inherit
+     - Motif database passed to ``modisco report -m`` (optional).
+
+
+marginalize_parameters
+~~~~~~~~~~~~~~~~~~~~~~
+
+Skipped entirely when the top-level ``motifs`` is null.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - Key
+     - Default
+     - Description
+   * - ``loci``
+     - inherit ``negatives``
+     - Background loci to insert motifs into.
+   * - ``n_loci``
+     - 100
+     - Number of background loci per motif.
+   * - ``attributions``
+     - ``false``
+     - Compute attributions on the inserted motif.
+   * - ``batch_size``
+     - 512
+     - Inference batch size.
+   * - ``shuffle``
+     - ``false``
+     - Shuffle the background loci before sampling.
+   * - ``random_state``
+     - 0
+     - RNG seed for shuffling.
+   * - ``minimal``
+     - ``true``
+     - Use the minimal marginalization output format.
+   * - ``output_filename``
+     - ``"{name}_marginalize/"``
+     - Output directory.
+
+
+cherimoya fit
+-------------
+
+CLI flags:
+
+* ``-p, --parameters`` (required) — path to a fit JSON.
+
+JSON schema: the ``fit_parameters`` table above, plus the input
+keys ``sequences``, ``loci``, ``negatives``, ``signals``,
+``controls``, ``exclusion_lists``, and ``performance_filename``
+(default ``"performance.tsv"``). On completion, ``fit`` also writes
+the resulting ``evaluate`` JSON and invokes the evaluate step.
+
+
+cherimoya evaluate
+------------------
+
+CLI flags:
+
+* ``-p, --parameters`` (required) — path to an evaluate JSON.
+
+JSON schema:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - Key
+     - Default
+     - Description
+   * - ``model``
+     - ``null``
+     - Path to a saved ``.torch`` checkpoint.
+   * - ``sequences``
+     - ``null``
+     - Reference genome FASTA.
+   * - ``loci``
+     - ``null``
+     - BED of evaluation loci.
+   * - ``controls``
+     - ``null``
+     - Optional list of control bigWigs (must match training).
+   * - ``signals``
+     - ``null``
+     - Signal bigWigs (must match training, for computing metrics).
+   * - ``chroms``
+     - ``["chr8", "chr20"]``
+     - Held-out chromosomes.
+   * - ``in_window`` / ``out_window``
+     - 2114 / 1000
+     - Window sizes (must match training).
+   * - ``batch_size``
+     - 512
+     - Inference batch size.
+   * - ``reverse_complement_average``
+     - ``false``
+     - Run predictions on RC inputs and average the results.
+   * - ``device`` / ``dtype``
+     - ``"cuda"`` / ``"float32"``
+     - Inference device and dtype.
+   * - ``exclusion_lists``
+     - ``null``
+     - Optional regions to exclude.
+   * - ``performance_filename``
+     - ``"performance.tsv"``
+     - TSV with one row of summary metrics.
+
+The TSV reports the mean of the following measures across examples:
+``profile_mnll``, ``profile_jsd``, ``profile_pearson``,
+``profile_spearman``, ``count_pearson``, ``count_spearman``,
+``count_mse``.
+
+
+cherimoya attribute
+-------------------
+
+CLI flags:
+
+* ``-p, --parameters`` (required) — path to an attribute JSON.
+
+JSON schema: the ``attribute_parameters`` table above, plus
+``model``, ``sequences``, ``loci``, ``exclusion_lists``, and
+``in_window`` / ``out_window``.
+
+
+cherimoya seqlets
+-----------------
+
+CLI flags:
+
+* ``-p, --parameters`` (required) — path to a seqlets JSON.
+
+JSON schema: the ``seqlet_parameters`` table above, plus ``chroms``
+and ``loci`` (needed to convert example-relative seqlet coordinates
+back to genome coordinates) and ``exclusion_lists``.
+
+
+cherimoya marginalize
+---------------------
+
+CLI flags:
+
+* ``-p, --parameters`` (required) — path to a marginalize JSON.
+
+JSON schema: the ``marginalize_parameters`` table above, plus
+``sequences``, ``model``, and ``motifs``.
+
+
+cherimoya negatives
+-------------------
+
+Sample GC-matched negative regions for a peak file. All flags are
+direct CLI arguments (no JSON):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 14 64
+
+   * - Flag
+     - Type
+     - Description
+   * - ``-i, --peaks``
+     - path (required)
+     - Peak BED.
+   * - ``-f, --fasta``
+     - path
+     - Reference genome FASTA.
+   * - ``-b, --bigwig``
+     - path
+     - Optional signal bigWig (used to set a minimum-counts threshold
+       on negatives via ``--beta``).
+   * - ``-o, --output``
+     - path (required)
+     - Output BED.
+   * - ``-l, --bin_width``
+     - float
+     - GC bin width to match. Default 0.02.
+   * - ``-n, --max_n_perc``
+     - float
+     - Maximum fraction of ``N`` bases allowed per locus. Default 0.1.
+   * - ``-a, --beta``
+     - float
+     - Multiplier on the minimum peak counts when filtering negatives
+       by signal. Default 0.5.
+   * - ``-w, --in_window``
+     - int
+     - Window over which GC content is calculated. Default 2114.
+   * - ``-x, --out_window``
+     - int
+     - Non-overlapping stride. Default 1000.
+   * - ``-v, --verbose``
+     - flag
+     - Print per-step progress.
+
+
+cherimoya batch
+---------------
+
+Run multiple pipelines in parallel using joblib.
+
+CLI flags:
+
+* ``-p, --parameters`` (required) — path to a batch JSON.
+
+The batch JSON is the same shape as a pipeline JSON with two
+additions:
+
+* ``"device": "*"`` is expanded to all available CUDA devices.
+* ``"signals"`` may be a glob string (``"data/*.bam"``). When set,
+  it's expanded to a list of paths, and ``"name"`` is auto-derived
+  from filenames if it is ``null``.
+
+Other list-valued fields (``loci``, ``negatives``, ``controls``) must
+be either ``null`` or a same-length list as the expanded
+``signals``. Each job is written to ``{name}.pipeline.json`` and run
+via ``subprocess.run(["cherimoya", "pipeline", "-p", jname])``.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@ sys.path.insert(0, os.path.abspath('..'))
 project = 'Cherimoya'
 copyright = '2026, Jacob Schreiber'
 author = 'Jacob Schreiber'
-release = '0.0.1'
+release = '0.1.0'
 
 # -- General configuration ---------------------------------------------------
 
@@ -24,7 +24,9 @@ extensions = [
 ]
 
 templates_path = ['_templates']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store',
+    '.ipynb_checkpoints', '**/.ipynb_checkpoints',
+    '.ipynb_checkpoints/**', '**/.ipynb_checkpoints/**']
 
 # Napoleon settings for NumPy-style docstrings
 napoleon_google_docstrings = False

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1,0 +1,193 @@
+Development
+===========
+
+This page is for contributors and integrators: how the source tree
+is organized, how to run the tests, and the conventions the
+codebase follows. End users do not need to read this.
+
+
+Repository layout
+-----------------
+
+::
+
+   cherimoya/
+   ├── cherimoya/                  # The Python package
+   │   ├── __init__.py             # Public API re-exports: Cherimoya, CheriBlock, EMA
+   │   ├── cherimoya.py            # Cherimoya model + EMA wrapper + fit/save/load
+   │   ├── cheri.py                # CheriBlock + Triton kernels + dispatcher
+   │   ├── io.py                   # PeakGenerator + PeakNegativeSampler
+   │   ├── losses.py               # Profile MNLL + log1pMSE mixture loss
+   │   └── performance.py          # Evaluation metrics
+   ├── cherimoya_cli/              # The CLI entry-point package
+   │   ├── __main__.py             # Argparse driver and subcommand registry
+   │   ├── defaults.py             # All default JSON parameter dicts
+   │   ├── utils.py                # JSON merging and parameter helpers
+   │   └── commands/               # One file per subcommand
+   │       ├── pipeline.py
+   │       ├── pipeline_json.py
+   │       ├── batch.py
+   │       ├── fit.py
+   │       ├── evaluate.py
+   │       ├── attribute.py
+   │       ├── seqlets.py
+   │       ├── marginalize.py
+   │       └── negatives.py
+   ├── tests/                      # Pytest suite (see below)
+   ├── docs/                       # Sphinx docs (this site)
+   ├── imgs/                       # Architecture / pipeline diagrams
+   ├── bench_kernels.py            # Standalone forward-path benchmark
+   └── pyproject.toml              # Build, deps, and tooling config
+
+Two top-level packages: ``cherimoya`` is the model and data plumbing,
+``cherimoya_cli`` is the command-line tool. They are independent —
+``cherimoya_cli`` imports ``cherimoya``, never the reverse.
+
+
+Public vs. private API
+----------------------
+
+The convention is the standard Python one: anything prefixed with an
+underscore is private, and may change or be removed without notice.
+Explicitly:
+
+* **Public** symbols, re-exported from ``cherimoya.__init__``:
+  :class:`~cherimoya.Cherimoya`, :class:`~cherimoya.CheriBlock`,
+  :class:`~cherimoya.cherimoya.EMA`.
+* **Public** module-level symbols:
+  :func:`~cherimoya.io.PeakGenerator`,
+  :class:`~cherimoya.io.PeakNegativeSampler`,
+  :func:`~cherimoya.cheri.fused_dilated_conv_norm`,
+  :class:`~cherimoya.cheri.FusedDilatedConvNormFunc`,
+  :func:`~cherimoya.performance.calculate_performance_measures` and
+  its component metrics, :func:`~cherimoya.losses._mixture_loss`
+  (despite the underscore — it is the trainer's loss function and
+  the API is stable).
+* **Private** and may change: anything else, including the Triton
+  kernels (``_fwd_*``, ``_bwd_*``, ``_fwd_inf_*``), the CPU fallback
+  (``_cheri_conv_norm_cpu``), the CheriBlock weight cache
+  (``_w_cache``), and the model's checkpoint-payload helper
+  (``_init_kwargs``).
+
+
+Development install
+-------------------
+
+For development, install in editable mode with the ``docs`` extra:
+
+.. code-block:: bash
+
+   git clone https://github.com/jmschrei/cherimoya.git
+   cd cherimoya
+   pip install -e .[docs]
+
+The ``docs`` extra adds ``sphinx``, ``furo``, and
+``sphinx-copybutton``, which you need to build this documentation
+locally:
+
+.. code-block:: bash
+
+   cd docs
+   sphinx-build -b html . _build
+
+The build produces ``docs/_build/index.html``. Read the Docs runs the
+same command with the same dependency set.
+
+
+Running the tests
+-----------------
+
+The test suite lives in ``tests/`` and uses pytest.
+
+.. code-block:: bash
+
+   pytest tests/
+
+Test files:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - File
+     - Covers
+   * - ``tests/test_cheri.py``
+     - Cheri Block forward parity (CPU vs training Triton vs
+       inference megakernel), backward parity against CPU
+       autograd, weight-cache invalidation, dtype matrix.
+   * - ``tests/test_model.py``
+     - Full Cherimoya forward/backward parity, no_grad ==
+       grad-enabled equivalence, EMA-applied save/load round trip.
+   * - ``tests/test_io.py``
+     - ``PeakGenerator`` and ``PeakNegativeSampler`` reproducibility,
+       per-epoch determinism, multi-worker equivalence.
+   * - ``tests/test_ema.py``
+     - EMA update/apply/restore semantics.
+   * - ``tests/test_losses.py``
+     - ``_mixture_loss`` shapes and edge cases.
+   * - ``tests/test_performance.py``
+     - Evaluation-metric correctness.
+   * - ``tests/test_fit_wiring.py``
+     - End-to-end fit step on tiny data: confirms optimizers,
+       schedulers, EMA, and checkpoint paths are wired correctly.
+   * - ``tests/test_cli_utils.py``
+     - JSON merge and default-handling helpers.
+
+Markers:
+
+* ``@pytest.mark.cuda`` — requires a CUDA device; skipped on
+  CPU-only hosts.
+* ``@pytest.mark.triton`` — requires both a CUDA device and a
+  Triton install.
+
+Both markers are wired through ``tests/conftest.py``, which also
+disables ``torch.compile`` for the suite so tests don't pay the
+several-minute autotune cost on every run.
+
+To run only the CPU-safe subset:
+
+.. code-block:: bash
+
+   pytest tests/ -m "not cuda and not triton"
+
+To run only the GPU parity tests:
+
+.. code-block:: bash
+
+   pytest tests/ -m "cuda or triton"
+
+
+Benchmarking
+------------
+
+``bench_kernels.py`` at the repo root is a standalone script that
+times the three forward paths and checks they all agree within
+machine precision. It is intentionally not packaged with the
+install. Run it with:
+
+.. code-block:: bash
+
+   python bench_kernels.py
+
+See :doc:`benchmarks` for the published numbers and the measurement
+methodology.
+
+
+Coding conventions
+------------------
+
+* **Tabs, not spaces.** The codebase uses tab indentation throughout.
+* **Channels-last layout** ``(N, L, C)`` is used inside the Cheri
+  Block backbone. The input stem and output heads do the necessary
+  transpositions. New blocks should follow the same convention.
+* **fp32 for normalization statistics** even under bf16 autocast.
+  Both the CPU fallback and the Triton kernels accumulate ``sum`` /
+  ``sq_sum`` in fp32; this is load-bearing for stability and
+  shouldn't be changed casually.
+* **Triton autotune keys.** Kernels are keyed by ``(C, L)`` so the
+  same configuration is reused across batches with the same shapes.
+  Adding a new kernel that depends on a new shape parameter should
+  add that parameter to the key.
+* **No public bias terms inside Cheri Blocks.** The input stem,
+  profile head, and count head use biases; the block layers do not.
+  This is intentional (see :doc:`architecture`).

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -1,0 +1,134 @@
+Glossary
+========
+
+A quick reference for terms that appear throughout the documentation.
+Definitions are scoped to how the word is used inside Cherimoya, not
+to the broader literature.
+
+
+Sequence-to-function (S2F) model
+   A neural network that takes a DNA sequence as input and predicts a
+   biological readout (e.g. read coverage from a sequencing assay) at
+   each base or over the whole sequence. Cherimoya is an S2F model.
+
+One-hot encoded DNA
+   A DNA sequence of length ``L`` represented as a ``(4, L)`` tensor
+   where row 0 is the indicator for A, row 1 for C, row 2 for G, row 3
+   for T, and any ``N`` base is all zeros. ``tangermeme.utils.one_hot_encode``
+   produces this from a Python string; ``tangermeme.io.extract_loci``
+   produces this from a FASTA file plus a BED of loci.
+
+Profile and counts
+   Cherimoya predicts two things per input: a **profile** (per-base
+   logits over the output window — what the read coverage looks like
+   *shape*-wise) and a **counts** scalar or per-track count (the log
+   of the total number of reads expected in the window). The profile
+   is normalized into a probability distribution via softmax for the
+   MNLL loss; the counts are predicted in log space.
+
+Input window vs output window vs trimming
+   The model receives a longer sequence (``in_window``, default 2114
+   bp) than it predicts over (``out_window``, default 1000 bp). The
+   difference, half on each side, is the **trimming** — the
+   context the model uses to predict the central window. The default
+   trimming of 557 bp matches the model's receptive field.
+
+Receptive field
+   The number of input bases that can influence a single output
+   prediction. For Cherimoya's default 9-layer backbone it is 1115 bp.
+   The 21-bp input stem plus the dilated stack
+   (dilations ``1, 2, 4, …, 256``) gives this number.
+
+Saturation mutagenesis (in silico)
+   The exhaustive *in-silico* variant scan: for each position in a
+   region, evaluate the model on all four single-nucleotide
+   substitutions and record the predicted delta. Each base position
+   gets a 4-dim vector of "hypothetical importance scores", and
+   multiplying by the actual one-hot sequence yields the importance
+   of the base that *is* there. Cherimoya's ``attribute`` subcommand
+   wraps ``tangermeme.saturation_mutagenesis.saturation_mutagenesis``.
+
+Hypothetical vs actual importance
+   *Hypothetical* importance is the score every possible base would
+   have at each position (shape ``(4, L)`` per example). *Actual*
+   importance is the score the base that is actually there has,
+   computed by elementwise multiplying the hypothetical scores with
+   the one-hot encoding and summing across the base axis (shape
+   ``(L,)`` per example). Both are useful for different downstream
+   analyses.
+
+Seqlet
+   A contiguous subsequence with high attribution scores. Cherimoya
+   uses ``tangermeme.seqlet.recursive_seqlets`` to extract seqlets
+   from the actual-importance signal; the resulting BED file is the
+   input to TF-MoDISco.
+
+TF-MoDISco
+   *Transcription Factor MOtif Discovery from Importance SCOres.* An
+   algorithm that clusters seqlets across a dataset to discover
+   recurring motif patterns. Cherimoya's pipeline calls TF-MoDISco
+   as a downstream step and produces both an HDF5 of patterns and an
+   HTML report.
+
+tomtom-lite (``ttl``)
+   A fast motif-similarity tool used to label discovered seqlets
+   against a known motif database in MEME format (typically JASPAR).
+   Distinct from full TomTom; the ``-lite`` variant uses precomputed
+   score binning to score thousands of seqlets quickly.
+
+Marginalization
+   A causal evaluation of motif effects: insert a known motif from a
+   MEME database into the center of negative (non-peak) sequences and
+   measure the predicted change in profile and counts. Produces one
+   measurement per (motif, locus) pair.
+
+MEME format
+   The plain-text motif database format used by the MEME suite. A
+   motif is encoded as a position probability matrix. JASPAR releases
+   their database in this format.
+
+GC-matched negatives
+   Non-peak control regions selected to have the same GC-content
+   distribution as the peaks. Cherimoya uses these as negative
+   training examples; ``tangermeme.match.extract_matching_loci``
+   does the matching. Without GC-matching, the model can learn to
+   predict "peak vs background" via GC alone, which is uninformative.
+
+Muon optimizer
+   A second-order-flavored optimizer that orthogonalizes its update
+   matrix before applying it. Cherimoya uses Muon for the 2D
+   projection weights inside Cheri Blocks (the ``linear1`` and
+   ``linear2`` weights) and AdamW for everything else.
+
+Kendall-Gal uncertainty weighting
+   A technique for combining multi-task losses without a fixed
+   hyperparameter: each task gets a learnable scalar that scales its
+   loss, with a log-squared regularizer that prevents the scalar from
+   going to zero. Cherimoya uses two such scalars (``lw0`` for
+   profile loss, ``lw1`` for counts loss) and freezes them once their
+   gradients become negligible.
+
+EMA (exponential moving average)
+   A shadow copy of every model parameter that is updated as
+   ``shadow = decay * shadow + (1 - decay) * parameter`` after each
+   optimizer step. Cherimoya uses decay 0.999 by default. The shadow
+   weights produce smoother validation curves and are what gets
+   saved to the ``.torch`` checkpoint.
+
+Tn5 transposase / +4 / −4 shift
+   ATAC-seq uses the Tn5 transposase, which cuts and inserts adapters
+   at preferred positions. The cut site lies 4 bp into each end of
+   the resulting fragment. Pipelines correct for this by shifting +
+   strand alignments by +4 bp and − strand alignments by −5 bp (or
+   −4, used by Cherimoya for symmetry). The correction reflects where
+   Tn5 *cut*, which is the biologically meaningful event, rather than
+   where the read aligns.
+
+bam2bw
+   The streaming BAM/SAM/fragment-file → bigWig converter used by
+   the Cherimoya pipeline. It reads the input file (local or remote),
+   counts reads (or fragments, with optional shifts) into per-base
+   coverage bins, and emits one or two bigWig files (stranded or
+   unstranded). Cherimoya invokes it automatically when a pipeline
+   step receives BAM/SAM/fragment input; it can also be used
+   standalone.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,16 +8,9 @@ Cherimoya
 .. image:: https://img.shields.io/badge/python-3.10+-blue.svg
    :alt: Python 3.10+
 
-.. image:: https://img.shields.io/badge/CUDA-required-green.svg
-   :alt: CUDA required
-
 .. image:: https://img.shields.io/badge/license-MIT-green.svg
    :target: https://github.com/jmschrei/cherimoya/blob/main/LICENSE
    :alt: License
-
-.. image:: https://img.shields.io/badge/maintenance-active-brightgreen.svg
-   :alt: Maintenance
-
 
 
 .. image:: ../imgs/cherimoya.png
@@ -27,37 +20,70 @@ Cherimoya
 
 |
 
-**A lightweight genomic sequence-to-function model.**
+**A compact deep learning model for predicting genomic profile data from DNA
+sequence.**
 
-Cherimoya predicts genomic modalities — transcription factor binding, chromatin
-accessibility, and transcription initiation — from DNA sequence alone. It builds
-on concepts from BPNet and ChromBPNet while introducing architectural,
-algorithmic, and systems-level improvements for better stability, efficiency,
-and performance.
+Cherimoya predicts genomic modalities — transcription factor binding,
+chromatin accessibility, and transcription initiation — directly from DNA
+sequence. It pairs a lightweight ConvNeXt-style backbone with custom Triton
+GPU kernels for both training and inference, and ships with an end-to-end
+CLI that takes BAM files through peak calling, training, attribution, and
+motif discovery in a single command.
 
 .. admonition:: Under Active Development
 
-   Cherimoya is still evolving and may change in ways that are not backward
-   compatible. Please note the version you are using.
+   Cherimoya is still evolving and may introduce breaking changes between
+   versions. Pin the version you train with if you need to reload
+   checkpoints later.
 
 
-Why Cherimoya?
+Where to start
 --------------
 
-While popular S2F models like BPNet and ChromBPNet have revolutionized our
-ability to interpret regulatory sequences, they often require millions of
-parameters and extensive tuning. Cherimoya provides a modern alternative:
+* **Bioinformaticians** running Cherimoya on their data: read
+  :doc:`installation`, then :doc:`tutorials/cli_pipeline` for an
+  end-to-end walkthrough, then pick the recipe that matches your assay
+  in :doc:`recipes/chipseq_tf`, :doc:`recipes/atacseq`, or
+  :doc:`recipes/dnaseq`. Comparing across conditions?
+  :doc:`recipes/differential`.
+* **Researchers** using Cherimoya from Python: read
+  :doc:`installation`, then :doc:`tutorials/python_api`, then explore
+  :doc:`tutorials/attribution`, :doc:`tutorials/variant_effect`, and
+  :doc:`tutorials/save_load`.
+* **Developers** integrating Cherimoya or contributing to it: read
+  :doc:`development` for repo layout and the test suite, then
+  :doc:`architecture` and the :doc:`api/model` / :doc:`api/cheri`
+  reference pages.
 
-* **Efficient Architecture**: Uses significantly fewer parameters while
-  maintaining or exceeding state-of-the-art predictive performance.
-* **Speed**: Runs much faster on modern GPUs (e.g., H200) thanks
-  to  custom Triton kernels that fuse dilated convolutions and layer
-  normalization.
-* **Automated Tuning**: Replaces manual loss balancing heuristics with
-  learned weighting parameters that adapt to your data's signal-to-noise
-  characteristics.
-* **Modern Optimization**: Leverages the Muon optimizer and dual-optimizer
-  strategies to reduce training epochs and improve convergence.
+If a term is unfamiliar, :doc:`glossary` defines everything used in
+the rest of these docs. If something is going wrong, start with
+:doc:`troubleshooting`.
+
+
+Design highlights
+-----------------
+
+* **Cheri Blocks**. A dilated depthwise convolution fused with a
+  per-example layer normalization and a channel-mixing MLP, implemented
+  as a custom Triton kernel. The default 9-layer model is ~340K
+  parameters with a 1115 bp receptive field.
+* **Three forward paths, one set of weights**. A CPU fallback, a
+  Triton fwd+bwd kernel for training, and a fwd-only megakernel for
+  inference, all numerically equivalent up to ~1e-5 max-abs.
+* **Dual-optimizer training**. Muon for 2D projection weights, AdamW
+  for everything else, with hyperparameters tuned via large-scale
+  sweeps.
+* **Learned loss balancing**. Kendall-Gal uncertainty weighting with
+  two learnable scalars replaces a fixed profile/counts loss weight.
+* **EMA at evaluation**. An exponential moving average of the
+  parameters is maintained during training and used at evaluation,
+  smoothing both the validation curve and the final predictions.
+* **Stability-first defaults**. Small fixed residual scale at
+  initialization, no biases inside Cheri Blocks, no weight decay on
+  Muon-routed weights, and a 5-epoch warmup before cosine decay.
+
+See :doc:`architecture` for the full story and :doc:`benchmarks` for
+measured numbers.
 
 ---
 
@@ -67,22 +93,44 @@ parameters and extensive tuning. Cherimoya provides a modern alternative:
 
    installation
    quickstart
+   glossary
 
 .. toctree::
    :maxdepth: 2
    :caption: User Guide
 
    architecture
+   benchmarks
+   troubleshooting
+   development
+   CHANGELOG
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Command-Line Interface
+
    tutorials/cli_pipeline
+   cli
+   recipes/chipseq_tf
+   recipes/atacseq
+   recipes/dnaseq
+   recipes/differential
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Python API
+
    tutorials/python_api
    tutorials/attribution
-   CHANGELOG
+   tutorials/variant_effect
+   tutorials/save_load
 
 .. toctree::
    :maxdepth: 2
    :caption: API Reference
 
    api/model
+   api/cheri
    api/io
    api/losses
    api/performance

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,15 +7,24 @@ Requirements
 Cherimoya requires:
 
 - Python ≥ 3.10
-- PyTorch ≥ 2.6 (with CUDA support recommended)
-- A CUDA-capable GPU (for the fused Triton kernel)
+- PyTorch ≥ 2.9
+- A CUDA-capable GPU is **strongly recommended** for training and
+  high-throughput inference. A pure-PyTorch CPU fallback path is
+  provided for everything except the inference megakernel, so the
+  package can be installed and the model can be run on machines
+  without a GPU. Training on CPU is impractical at any realistic
+  scale.
 
-.. warning::
-   Cherimoya relies on `Triton <https://github.com/triton-lang/triton>`_ for its custom
-   GPU kernels. Due to its low-level nature, Triton requires a hardware-dependent
-   installation that varies based on your GPU architecture and CUDA version.
-   Please ensure your hardware is compatible and that you have the appropriate
-   drivers and PyTorch-compatible CUDA toolkit installed.
+.. note::
+
+   Cherimoya's custom GPU kernels are written in `Triton
+   <https://github.com/triton-lang/triton>`_. ``triton`` is a hard
+   dependency and is installed automatically from PyPI. On Linux with a
+   modern CUDA toolkit and a recent PyTorch wheel, this works without
+   any extra steps. On unusual configurations (custom CUDA versions,
+   non-x86 hosts) Triton may need to be installed against your specific
+   toolchain — see the Triton README for details.
+
 
 Install from PyPI
 -----------------
@@ -24,7 +33,7 @@ Install from PyPI
 
    pip install cherimoya
 
-Install from Source
+Install from source
 -------------------
 
 .. code-block:: bash
@@ -36,25 +45,24 @@ Install from Source
 Install with uv
 ---------------
 
-`uv <https://docs.astral.sh/uv/>`_ is a fast Python package manager that can be used
-as a drop-in replacement for pip.
+`uv <https://docs.astral.sh/uv/>`_ is a fast Python package manager that
+can be used as a drop-in replacement for pip:
 
 .. code-block:: bash
 
    uv pip install cherimoya
 
-Install from source with uv:
-
-.. code-block:: bash
-
+   # or, from source:
    git clone https://github.com/jmschrei/cherimoya.git
    cd cherimoya
    uv pip install -e .
 
+
 Dependencies
 ------------
 
-The following packages are installed automatically:
+The following packages are installed automatically. Pinned lower-bounds
+are taken from ``pyproject.toml``.
 
 .. list-table::
    :header-rows: 1
@@ -62,24 +70,39 @@ The following packages are installed automatically:
 
    * - Package
      - Purpose
-   * - ``torch``
-     - Deep learning framework
-   * - ``triton``
-     - Custom GPU kernel compilation
-   * - ``numpy``, ``scipy``, ``pandas``
-     - Numerical computing and data handling
-   * - ``h5py``
-     - HDF5 file I/O
-   * - ``tangermeme``
-     - Genomic sequence utilities and attribution
-   * - ``bpnet-lite``
-     - Loss functions and logging from BPNet
+   * - ``torch`` (≥ 2.9)
+     - Tensor framework and autograd.
+   * - ``triton`` (≥ 3.5.1)
+     - Custom GPU kernels for Cheri Blocks (fwd+bwd) and the inference
+       megakernel.
+   * - ``numpy`` (≥ 1.14), ``scipy`` (≥ 1.0), ``pandas`` (≥ 1.3.3)
+     - Numerical computing and tabular data handling.
+   * - ``h5py`` (≥ 3.7)
+     - HDF5 I/O (TF-MoDISco results, attribution arrays).
+   * - ``tqdm`` (≥ 4.64.1)
+     - Progress bars for data loading and training.
+   * - ``tangermeme`` (≥ 0.2.3)
+     - Sequence loading, attribution (saturation mutagenesis), and
+       seqlet extraction primitives.
+   * - ``bpnet-lite`` (≥ 1.0.0)
+     - Multinomial NLL and log1p-MSE losses; ControlWrapper /
+       CountWrapper / ProfileWrapper helpers used by the attribute and
+       marginalize subcommands.
    * - ``macs3``
-     - Peak calling
-   * - ``bam2bw``
-     - BAM/SAM to bigWig conversion
+     - Peak calling, invoked by the ``pipeline`` subcommand.
+   * - ``bam2bw`` (≥ 0.4.1)
+     - BAM/SAM/fragment file → bigWig conversion; used by the
+       ``pipeline`` subcommand and supports remote input URLs.
+   * - ``modisco`` (≥ 2.0)
+     - TF-MoDISco motif discovery, invoked by the ``pipeline``
+       subcommand.
+   * - ``seaborn`` (≥ 0.11.2)
+     - Plotting used by the marginalization report.
+   * - ``joblib`` (≥ 1.0.0)
+     - Parallel execution backend for the ``batch`` subcommand.
 
-Optional Dependencies
+
+Optional dependencies
 ---------------------
 
 .. list-table::
@@ -89,13 +112,16 @@ Optional Dependencies
    * - Package
      - Purpose
    * - ``scikit-learn``
-     - Required only for AUROC/AUPRC evaluation metrics
-   * - ``modisco``
-     - TF-MoDISco motif discovery
-   * - ``seaborn``
-     - Visualization
+     - Required only for the ``auroc`` / ``auprc`` measures inside
+       :func:`cherimoya.performance.calculate_performance_measures`.
+       The rest of the package does not import it.
 
-Verifying the Installation
+Documentation build dependencies (``sphinx``, ``furo``,
+``sphinx-copybutton``) are listed under the ``docs`` extra in
+``pyproject.toml`` and can be installed with ``pip install -e .[docs]``.
+
+
+Verifying the installation
 --------------------------
 
 .. code-block:: python
@@ -104,5 +130,75 @@ Verifying the Installation
    print(cherimoya.__version__)
 
    from cherimoya import Cherimoya
-   model = Cherimoya(n_filters=64, n_layers=9)
-   print(f"Parameters: {sum(p.numel() for p in model.parameters()):,}")
+   model = Cherimoya(n_filters=96, n_layers=9)
+   print("Parameters:", sum(p.numel() for p in model.parameters()))
+
+The default 9-layer model has roughly 340K parameters. The package will
+import and the model will instantiate without a GPU; a CUDA device is
+only needed when you call ``.cuda()`` or pass tensors that live on a
+GPU.
+
+
+Hardware expectations
+---------------------
+
+The default 9-layer, 96-filter Cherimoya model is small (~340K
+parameters). The dominant memory cost during training is the
+activations and the optimizer state, not the parameters; both scale
+linearly with ``batch_size``, ``in_window``, and ``n_filters``.
+
+In practice:
+
+* The default training configuration (``batch_size=64``,
+  ``in_window=2114``, ``n_filters=96``, 9 layers) fits comfortably on
+  a 16 GB GPU.
+* Inference at ``batch_size=512`` (the CLI default) fits on the same
+  hardware.
+* If you have less VRAM, reduce ``batch_size`` first; reducing
+  ``n_filters`` is a secondary lever.
+
+Training time scales linearly with peak count and epochs and is
+dominated by the dataloader for typical configurations. For a
+ChIP-seq target with a few tens of thousands of peaks and the default
+50-epoch schedule, full training is a tens-of-minutes operation on a
+modern data-center GPU. See :doc:`benchmarks` for measured forward
+times.
+
+
+Smoke test
+----------
+
+The fastest way to confirm a working install end-to-end is to
+instantiate a model, run one forward pass on random input, and check
+that the output shapes are right:
+
+.. code-block:: python
+
+   import torch
+   from cherimoya import Cherimoya
+
+   model = Cherimoya(n_filters=96, n_layers=9, n_outputs=1)
+   if torch.cuda.is_available():
+       model = model.cuda()
+
+   X = torch.randn(2, 4, 2114)
+   if torch.cuda.is_available():
+       X = X.cuda()
+
+   with torch.no_grad():
+       y_profile, y_counts = model(X)
+
+   print(y_profile.shape)   # torch.Size([2, 1, 1000])
+   print(y_counts.shape)    # torch.Size([2, 1])
+
+If both shape prints match, your install is working through every
+forward path the model uses. The first call on GPU will spend a
+few seconds in Triton autotune — see
+:doc:`troubleshooting` if it stays slow.
+
+To run the full CLI pipeline end-to-end on real data, pick a small
+ChIP-seq target from ENCODE (CTCF in K562, for example), download
+the BAM and matched input BAM, and follow :doc:`recipes/chipseq_tf`.
+A short ChIP-seq dataset with ~30k peaks completes the full
+peak-calling-through-MoDISco pipeline in tens of minutes on a single
+modern GPU.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,144 +1,55 @@
 Quickstart
 ==========
 
-This page shows the two main ways to use Cherimoya: via the **command-line
-pipeline** or via the **Python API**.
+Two paste-and-run examples — one for each interface. For full
+walkthroughs see :doc:`tutorials/cli_pipeline` and
+:doc:`tutorials/python_api`. New to the terms? Skim :doc:`glossary`.
 
 
-Using the CLI Pipeline
-----------------------
+Command-line pipeline
+---------------------
 
-The fastest way to go from raw data to trained model and motif analysis is the
-end-to-end pipeline. You need:
-
-1. A genome FASTA file (e.g., ``hg38.fa``)
-2. One or more signal files (BAM, SAM, BED, or bigWig)
-3. (Optional) Control signal files
-
-**Step 1: Generate a pipeline JSON**
+For stranded ChIP-seq with input controls:
 
 .. code-block:: bash
 
    cherimoya pipeline-json \
-       -s hg38.fa \
-       -i signal.bam \
-       -n my_experiment \
-       -o my_experiment.pipeline.json
+       -s hg38.fa -p peaks.narrowPeak \
+       -i input.bam -c control.bam \
+       -m JASPAR_2024.meme -n my_experiment -o pipeline.json
 
-**Step 2: Run the full pipeline**
+   cherimoya pipeline -p pipeline.json
 
-.. code-block:: bash
-
-   cherimoya pipeline -p my_experiment.pipeline.json
-
-This will automatically:
-
-- Call peaks using MACS3
-- Convert BAM files to bigWig format
-- Sample GC-matched negative regions
-- Train a Cherimoya model
-- Calculate attributions
-- Identify seqlets
-- Run TF-MoDISco motif discovery
+This calls peaks with MACS3, converts BAMs to bigWigs, samples
+GC-matched negatives, trains a Cherimoya model, computes attributions
+via saturation mutagenesis, calls seqlets, annotates them with
+tomtom-lite, and runs TF-MoDISco. All outputs land in the working
+directory; the full output list and per-step descriptions are in
+:doc:`tutorials/cli_pipeline`. Assay-specific recipes:
+:doc:`recipes/chipseq_tf`, :doc:`recipes/atacseq`,
+:doc:`recipes/dnaseq`.
 
 
-Using the Python API
---------------------
-
-For more control, use the Python API directly.
-
-**Instantiate a model:**
-
-.. code-block:: python
-
-   from cherimoya import Cherimoya
-
-   model = Cherimoya(
-       n_filters=96,       # Number of convolutional filters (default 96)
-       n_layers=9,         # Number of Cheri Blocks
-       n_outputs=2,        # Number of output tracks (e.g., 2 for stranded)
-       n_control_tracks=0, # Number of control tracks (0 if no controls)
-   ).cuda()
-
-**Load training data:**
-
-.. code-block:: python
-
-   from cherimoya.io import PeakGenerator
-
-   training_data = PeakGenerator(
-       peaks="peaks.narrowPeak",
-       negatives="negatives.bed",
-       sequences="hg38.fa",
-       signals=["signal.+.bw", "signal.-.bw"],
-       chroms=["chr1", "chr2", "chr3"],  # Training chromosomes
-       in_window=2114,
-       out_window=1000,
-       max_jitter=128,
-       batch_size=64,
-   )
-
-**Set up optimizers and train:**
-
-.. code-block:: python
-
-   from torch.optim import AdamW, Muon
-   from torch.optim.lr_scheduler import LinearLR, CosineAnnealingLR, SequentialLR
-
-   # Separate parameters for Muon (2D weights) and AdamW (everything else)
-   muon_params, adam_params = [], []
-   for name, p in model.named_parameters():
-       if p.ndim == 2 and "weight" in name and name != "linear.weight":
-           muon_params.append(p)
-       else:
-           adam_params.append(p)
-
-   muon_optimizer = Muon(muon_params, lr=0.01)
-   adam_optimizer = AdamW(adam_params, lr=0.004)
-
-   # Warmup + cosine decay schedules
-   n_warmup = len(training_data) * 5
-   n_total = len(training_data) * 50
-
-   muon_scheduler = SequentialLR(muon_optimizer, schedulers=[
-       LinearLR(muon_optimizer, start_factor=0.01, total_iters=n_warmup),
-       CosineAnnealingLR(muon_optimizer, T_max=n_total, eta_min=1e-5),
-   ], milestones=[n_warmup])
-
-   adam_scheduler = SequentialLR(adam_optimizer, schedulers=[
-       LinearLR(adam_optimizer, start_factor=0.01, total_iters=n_warmup),
-       CosineAnnealingLR(adam_optimizer, T_max=n_total, eta_min=1e-5),
-   ], milestones=[n_warmup])
-
-   # Train
-   model.fit(
-       training_data,
-       muon_optimizer, adam_optimizer,
-       muon_scheduler, adam_scheduler,
-       X_valid=X_valid,
-       X_ctl_valid=None,
-       y_valid=y_valid,
-       max_epochs=50,
-       batch_size=64,
-   )
-
-**Make predictions:**
-
-.. code-block:: python
-
-   from tangermeme.predict import predict
-
-   y_profile, y_counts = predict(
-       model, X_test,
-       batch_size=64,
-       device='cuda',
-   )
-
-
-Next Steps
+Python API
 ----------
 
-- :doc:`architecture` — understand the Cheri Block and model design
-- :doc:`tutorials/cli_pipeline` — detailed CLI pipeline walkthrough
-- :doc:`tutorials/python_api` — full Python API tutorial
-- :doc:`tutorials/attribution` — attribution and motif analysis
+.. code-block:: python
+
+   import torch
+   from cherimoya import Cherimoya
+
+   model = Cherimoya(n_filters=96, n_layers=9, n_outputs=1).cuda()
+   X = torch.randn(2, 4, 2114, device="cuda")
+   with torch.no_grad():
+       y_profile, y_counts = model(X)
+
+   print(y_profile.shape)   # torch.Size([2, 1, 1000])
+   print(y_counts.shape)    # torch.Size([2, 1])
+
+To one-hot encode real DNA, use ``tangermeme.utils.one_hot_encode``
+(for a Python string) or ``tangermeme.io.extract_loci`` (for a FASTA
+plus a BED of loci). To train from scratch with the same defaults the
+CLI uses, see :doc:`tutorials/python_api`. To save and load
+checkpoints, see :doc:`tutorials/save_load`. To compute attributions
+or score variants, see :doc:`tutorials/attribution` and
+:doc:`tutorials/variant_effect`.

--- a/docs/recipes/atacseq.rst
+++ b/docs/recipes/atacseq.rst
@@ -1,0 +1,108 @@
+Recipe: ATAC-seq
+================
+
+This recipe trains an unstranded Cherimoya model on paired-end
+ATAC-seq, applying the standard +4 / −4 fragment shift to match the
+Tn5 insertion offsets. ATAC-seq is typically modeled as a single
+unstranded output track.
+
+
+Inputs
+------
+
+* Reference genome FASTA (e.g. ``hg38.fa``).
+* A BAM file of aligned ATAC-seq paired-end reads, **or** a BED/TSV
+  fragment file.
+* A motif database in MEME format.
+* Optional: a BED of peak coordinates. If not provided, MACS3 will
+  call peaks.
+
+
+About the +4 / −4 shift
+-----------------------
+
+Tn5 transposes 9 bp apart and the standard correction many tools
+apply is +4 / −5. Cherimoya's defaults and this recipe use **+4 / −4**
+because the model treats the two end events symmetrically and the
+−5 / −4 difference is not biologically meaningful at the resolution
+Cherimoya predicts. Apply the shift here, not upstream, and **don't
+double-shift** — if your BAM is already shifted, set the shifts to
+zero.
+
+
+Generate the pipeline JSON
+--------------------------
+
+For a paired-end BAM:
+
+.. code-block:: bash
+
+   cherimoya pipeline-json \
+       -s hg38.fa \
+       -i atac.bam \
+       -m JASPAR_2024.meme \
+       -n atac_experiment \
+       -o atac.pipeline.json \
+       -ps 4 -ns -4 -u -f -pe
+
+Flag-by-flag:
+
+* ``-ps 4`` / ``-ns -4`` — Tn5 shift on plus and minus ends.
+* ``-u`` — unstranded output (single signal track).
+* ``-f`` — treat the input as fragments. With ``-pe`` set, ``bam2bw``
+  reads paired-end mates to reconstruct fragments before counting.
+* ``-pe`` — paired-end. Causes MACS3 to use ``BAMPE`` file format
+  rather than ``BAM``.
+
+If your input is already a fragments TSV/BED (e.g. from
+``snap-atac``, ``CellRanger``, or a custom ``samtools`` pipeline),
+pass the fragment file with ``-i`` and drop ``-pe``; ``bam2bw``
+detects the file extension and handles the fragment file format.
+
+
+Run the pipeline
+----------------
+
+.. code-block:: bash
+
+   cherimoya pipeline -p atac.pipeline.json
+
+The steps mirror the ChIP-seq recipe, with these differences:
+
+* MACS3 runs without a control file and with format ``BAMPE`` (or
+  ``FRAG`` for fragment-file input).
+* ``bam2bw`` is invoked with the ``-u`` (unstranded), ``-f``
+  (fragments), and ``-ps 4 -ns -4`` flags, producing a single
+  ``atac_experiment.bw`` rather than ``+.bw`` / ``-.bw`` pair.
+* The trained Cherimoya model has ``n_outputs=1`` and
+  ``n_control_tracks=0``.
+* Attribution, seqlet calling, TF-MoDISco, and marginalization run
+  the same way they do for ChIP-seq.
+
+
+ATAC-seq peak counts can be noisier
+-----------------------------------
+
+ATAC-seq peaks span a wider range of summit heights than TF ChIP-seq.
+Two parameters are worth checking after a first training run:
+
+* ``fit_parameters.max_counts`` — if the training log shows very
+  large gradient norms early in training, cap outlier peaks by
+  setting this. The default ``PeakGenerator`` filter already drops
+  peaks above ``1.2 × the 99th percentile`` of summed counts; setting
+  ``max_counts`` adds an explicit ceiling on top of that.
+* ``fit_parameters.max_jitter`` — the default of 50 is conservative.
+  ATAC-seq peaks are typically wide enough that 128 is also safe and
+  improves training-set diversity. Match this with ``in_window``
+  large enough to absorb the jitter (``in_window`` is 2114 by
+  default; ``max_jitter`` ≤ 128 fits comfortably).
+
+
+Outputs
+-------
+
+See the "Outputs" table in :doc:`../tutorials/cli_pipeline`. ATAC-seq
+runs produce one unstranded bigWig (``atac_experiment.bw``) rather
+than a stranded pair, and the model has a single profile track. The
+HTML reports under ``atac_experiment_modisco/`` and
+``atac_experiment_marginalize/`` are the same format as ChIP-seq.

--- a/docs/recipes/chipseq_tf.rst
+++ b/docs/recipes/chipseq_tf.rst
@@ -1,0 +1,123 @@
+Recipe: TF ChIP-seq
+===================
+
+This recipe trains a stranded Cherimoya model on transcription factor
+ChIP-seq with input controls. ChIP-seq data is typically single-end
+and stranded, and the standard practice is to model the + and -
+strand coverage as two separate output tracks.
+
+
+Inputs
+------
+
+* Reference genome FASTA (e.g. ``hg38.fa``).
+* One or more BAM files of aligned ChIP-seq reads.
+* One or more BAM files of aligned input controls.
+* A motif database in MEME format (e.g. ``JASPAR_2024.meme``).
+* Optional: a BED of peak coordinates. If not provided, MACS3 will
+  call peaks.
+
+
+Generate the pipeline JSON
+--------------------------
+
+.. code-block:: bash
+
+   cherimoya pipeline-json \
+       -s hg38.fa \
+       -i ctcf_rep1.bam -i ctcf_rep2.bam \
+       -c input_rep1.bam -c input_rep2.bam \
+       -m JASPAR_2024.meme \
+       -n ctcf \
+       -o ctcf.pipeline.json
+
+If you already have peak coordinates, add ``-p ctcf_peaks.narrowPeak``.
+
+The defaults populated into the JSON are:
+
+* Stranded output (``unstranded: false``).
+* No read shift (``pos_shift: 0``, ``neg_shift: 0``).
+* Single-end (``paired_end: false``, ``fragments: false``).
+* MACS3 q-value 0.05 with auto-detected file format (``BAM`` for BAM
+  inputs, ``BAMPE`` when ``paired_end: true``).
+
+These are appropriate for typical TF ChIP-seq. If your ChIP-seq is
+paired-end, override with ``-pe`` at this step or set
+``"paired_end": true`` in the JSON.
+
+
+Run the pipeline
+----------------
+
+.. code-block:: bash
+
+   cherimoya pipeline -p ctcf.pipeline.json
+
+Steps invoked, in order:
+
+1. MACS3 peak calling on the ChIP BAMs with the input BAMs as
+   controls (output: ``ctcf_peaks.narrowPeak``).
+2. ``bam2bw`` converts the ChIP and input BAMs to stranded bigWigs
+   (``ctcf.+.bw``, ``ctcf.-.bw``, ``ctcf.control.+.bw``,
+   ``ctcf.control.-.bw``).
+3. GC-matched negative sampling (``ctcf.negatives.bed``).
+4. Train a 9-layer 96-filter Cherimoya model with
+   ``n_outputs=2`` (the two strands) and ``n_control_tracks=2``.
+5. Compute count attributions via saturation mutagenesis on the
+   validation chromosomes.
+6. Call seqlets, annotate with tomtom-lite against
+   ``JASPAR_2024.meme``.
+7. Run TF-MoDISco motif discovery and generate the HTML report.
+8. Marginalize each motif at the center of negative loci and
+   generate the marginalization report.
+
+
+Common overrides
+----------------
+
+If you want to deviate from defaults, edit the JSON before running
+``cherimoya pipeline``. The most commonly overridden keys:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - Key path
+     - Default
+     - When to change
+   * - ``fit_parameters.n_filters``
+     - 96
+     - Smaller (64) for faster experiments; larger (128) for very
+       complex assays.
+   * - ``fit_parameters.n_layers``
+     - 9
+     - Reduce to shrink receptive field (``RF = 46 + sum(2^i)``);
+       9 layers → 1115 bp.
+   * - ``fit_parameters.max_epochs``
+     - 50
+     - Reduce for quick smoke tests; increase only if the validation
+       count Pearson is still climbing at epoch 50.
+   * - ``fit_parameters.training_chroms`` / ``validation_chroms``
+     - hg38 default split (chr8/chr20 validation)
+     - For non-hg38 references, replace with the appropriate
+       chromosome list.
+   * - ``preprocessing_parameters.callpeaks_gsize``
+     - ``"hs"``
+     - Set to ``"mm"`` for mouse, or a numeric effective genome size
+       for other organisms.
+   * - ``preprocessing_parameters.callpeaks_q``
+     - 0.05
+     - Loosen (0.1) for low-yield experiments, tighten (0.01) for
+       very confident calls.
+
+
+Outputs
+-------
+
+See the "Outputs" table in :doc:`../tutorials/cli_pipeline` for the
+full list. The two most useful artifacts for downstream analysis are:
+
+* ``ctcf.torch`` — the trained model, loadable with
+  :meth:`cherimoya.Cherimoya.load`.
+* ``ctcf_modisco/`` — the TF-MoDISco HTML report showing discovered
+  motifs and their seqlet support.

--- a/docs/recipes/differential.rst
+++ b/docs/recipes/differential.rst
@@ -1,0 +1,148 @@
+Recipe: Differential / Conditional Analysis
+===========================================
+
+This recipe covers comparing two (or more) conditions — treated vs.
+control, knockout vs. wildtype, time point A vs. B. The standard
+pattern in Cherimoya is to train one model per condition, then
+compare their predictions on a shared set of loci. This is simpler
+to set up than a single multi-output model and gives cleaner
+attribution and marginalization results.
+
+If you have only a single condition, use the assay-specific recipe
+(:doc:`chipseq_tf`, :doc:`atacseq`, or :doc:`dnaseq`) instead.
+
+
+Inputs
+------
+
+* Reference genome FASTA.
+* Per-condition signal BAMs (with replicates pooled or treated as
+  separate ``-i`` files).
+* Per-condition control BAMs (for ChIP-seq) or none (for ATAC/DNase).
+* A motif database in MEME format.
+
+
+Step 1: train one model per condition
+--------------------------------------
+
+Generate one pipeline JSON per condition and run them sequentially
+(or in parallel via the ``batch`` subcommand; see :doc:`../cli`):
+
+.. code-block:: bash
+
+   cherimoya pipeline-json \
+       -s hg38.fa \
+       -i condA_rep1.bam -i condA_rep2.bam \
+       -c condA_input.bam \
+       -m JASPAR_2024.meme -n condA -o condA.pipeline.json
+
+   cherimoya pipeline-json \
+       -s hg38.fa \
+       -i condB_rep1.bam -i condB_rep2.bam \
+       -c condB_input.bam \
+       -m JASPAR_2024.meme -n condB -o condB.pipeline.json
+
+   cherimoya pipeline -p condA.pipeline.json
+   cherimoya pipeline -p condB.pipeline.json
+
+Each run produces a model checkpoint (``condA.torch`` /
+``condB.torch``), per-track bigWigs, attributions, seqlets, and a
+TF-MoDISco report scoped to that condition's peaks.
+
+Use the same ``training_chroms`` / ``validation_chroms`` in both
+JSONs so the held-out evaluation is comparable.
+
+
+Step 2: build a shared locus set
+--------------------------------
+
+Decide what regions to compare across. The natural choices, in
+increasing order of conservatism:
+
+* **Union** of condition-A and condition-B peaks — catches gains and
+  losses but includes weakly-supported regions.
+* **Intersection** — only regions called as peaks in both
+  conditions; conservative but misses pure gains/losses.
+* **Union over a reference annotation** (e.g. promoters,
+  GENCODE-defined TSSes) — gives a biologically interpretable set
+  that doesn't depend on the peak calls.
+
+A typical union with ``bedtools``:
+
+.. code-block:: bash
+
+   cat condA_peaks.narrowPeak condB_peaks.narrowPeak | \
+       sort -k1,1 -k2,2n | \
+       bedtools merge -i - > shared_loci.bed
+
+
+Step 3: predict from both models on the shared set
+--------------------------------------------------
+
+.. code-block:: python
+
+   from cherimoya import Cherimoya
+   from tangermeme.io import extract_loci
+   from tangermeme.predict import predict
+
+   model_A = Cherimoya.load("condA.torch", device="cuda")
+   model_B = Cherimoya.load("condB.torch", device="cuda")
+   model_A.eval(); model_B.eval()
+
+   X, _ = extract_loci(
+       sequences="hg38.fa",
+       loci="shared_loci.bed",
+       chroms=["chr8", "chr20"],     # the held-out chromosomes used during training
+       in_window=2114, out_window=1000, max_jitter=0,
+       ignore=list('QWERYUIOPSDFHJKLZXVBNM'),
+       return_mask=True,
+   )
+
+   y_prof_A, y_counts_A = predict(model_A, X, batch_size=64, device="cuda")
+   y_prof_B, y_counts_B = predict(model_B, X, batch_size=64, device="cuda")
+
+   # Differences in log counts (predicted log fold change).
+   delta_log_counts = y_counts_B - y_counts_A
+
+Loci with large positive ``delta_log_counts`` are predicted to gain
+signal in condition B; large negative values are predicted losses.
+
+
+Step 4: identify differential motifs
+------------------------------------
+
+For motif-level differences, run marginalization on both models and
+compare. Each model's pipeline already runs marginalization on its
+own negative loci; to compare directly, run marginalization on a
+**shared** background:
+
+.. code-block:: bash
+
+   cherimoya marginalize -p marginalize_A.json
+   cherimoya marginalize -p marginalize_B.json
+
+with the two JSONs differing only in ``model`` and ``output_filename``,
+but identical in ``loci`` (the shared background) and ``motifs``. The
+delta in per-motif marginalization scores between A and B is a
+direct estimate of which motifs cause the condition-specific signal.
+
+
+Caveats
+-------
+
+* **Held-out chromosomes must match.** A model trained with
+  ``chr8``/``chr20`` as validation cannot be compared with one
+  trained with ``chr1``/``chr12`` as validation on common loci —
+  some of those loci were in the second model's training set. Use
+  the same split in both JSONs.
+* **Replicate-to-replicate noise is the floor.** Before treating
+  ``delta_log_counts`` as biological signal, compare to the
+  technical-replicate baseline by training two models on independent
+  replicates of the same condition and computing the same delta.
+  Biological deltas should be larger than the replicate baseline.
+* **The two models share no parameters.** Each model is fit
+  independently and the comparison happens only at prediction time.
+  Multi-output single-model training is possible by passing
+  ``-i condA.bw -i condB.bw`` to one pipeline (Cherimoya treats each
+  signal as a separate output track), but in practice per-condition
+  models give cleaner attribution and motif results.

--- a/docs/recipes/dnaseq.rst
+++ b/docs/recipes/dnaseq.rst
@@ -1,0 +1,92 @@
+Recipe: DNase-seq
+=================
+
+This recipe trains a Cherimoya model on DNase-seq, which measures
+chromatin accessibility via DNase I hypersensitivity. DNase-seq is
+typically single-end and is most commonly modeled as a single
+unstranded output track, although stranded variants exist.
+
+If your data is paired-end ATAC-seq instead, see :doc:`atacseq`.
+
+
+Inputs
+------
+
+* Reference genome FASTA (e.g. ``hg38.fa``).
+* A BAM file of aligned single-end DNase-seq reads.
+* A motif database in MEME format.
+* Optional: a BED of peak coordinates. If not provided, MACS3 will
+  call peaks.
+
+
+Generate the pipeline JSON
+--------------------------
+
+.. code-block:: bash
+
+   cherimoya pipeline-json \
+       -s hg38.fa \
+       -i dnase.bam \
+       -m JASPAR_2024.meme \
+       -n dnase_experiment \
+       -o dnase.pipeline.json \
+       -u
+
+Flag-by-flag:
+
+* ``-u`` — unstranded output (single signal track). The most common
+  setup for DNase-seq.
+* No ``-pe`` (single-end reads).
+* No ``-f`` (the input is a BAM of aligned reads, not a fragment
+  file).
+* No shift by default. If your protocol calls for a DNase I-specific
+  shift (some pipelines apply +1 / 0 to mark cut sites), set
+  ``-ps`` / ``-ns`` here.
+
+For a stranded variant, omit ``-u``. Cherimoya will then produce two
+output tracks (+ and - strand) and the trained model will have
+``n_outputs=2``.
+
+
+Run the pipeline
+----------------
+
+.. code-block:: bash
+
+   cherimoya pipeline -p dnase.pipeline.json
+
+Steps invoked, in order:
+
+1. MACS3 peak calling on the BAM with no controls (output:
+   ``dnase_experiment_peaks.narrowPeak``).
+2. ``bam2bw`` converts the BAM to an unstranded bigWig
+   (``dnase_experiment.bw``).
+3. GC-matched negative sampling (``dnase_experiment.negatives.bed``).
+4. Train a 9-layer 96-filter Cherimoya model with ``n_outputs=1`` and
+   ``n_control_tracks=0``.
+5. Compute count attributions via saturation mutagenesis on the
+   validation chromosomes.
+6. Call seqlets, annotate with tomtom-lite.
+7. Run TF-MoDISco motif discovery.
+8. Marginalize each motif at the center of negative loci.
+
+
+Notes
+-----
+
+* DNase-seq has historically been processed by many slightly
+  different protocols. If you trust the upstream pipeline that
+  produced the BAM, you can leave the shift parameters at 0; if you
+  produced the BAM yourself and want footprint-resolution
+  predictions, a small ``+1 / 0`` shift sometimes improves results.
+* Like ATAC-seq, DNase-seq peaks can vary significantly in summit
+  height. The same ``max_counts`` / ``max_jitter`` advice from the
+  :doc:`atacseq` recipe applies.
+
+
+Outputs
+-------
+
+See the "Outputs" table in :doc:`../tutorials/cli_pipeline`. The
+trained model is at ``dnase_experiment.torch`` and the TF-MoDISco
+report is at ``dnase_experiment_modisco/``.

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -1,0 +1,202 @@
+Troubleshooting and FAQ
+=======================
+
+The most common things that go wrong on a first Cherimoya run, with
+the symptom each one produces and what to change. See :doc:`glossary`
+for any unfamiliar terms.
+
+
+Is my dataset big enough?
+-------------------------
+
+Two related questions: how many peaks, and how deep a library?
+
+**Peaks.** Cherimoya trains comfortably on tens of thousands of
+peaks. As a rough guide:
+
+* Fewer than ~2,000 peaks → expect underfitting; consider transfer
+  learning or pooling related experiments instead.
+* 2,000–10,000 peaks → workable but on the edge; reduce
+  ``n_filters`` to 48–64 and watch the validation count Pearson
+  carefully.
+* 10,000+ peaks → default configuration is appropriate.
+* 50,000+ peaks → no special handling needed; larger models
+  (``n_filters=128``) become worth trying.
+
+**Library depth.** Cherimoya needs enough reads per peak that the
+profile MNLL is informative. As a rough guide:
+
+* Fewer than ~50 reads per peak → MNLL is dominated by noise;
+  ``count_pearson`` may still be meaningful but profile-shape
+  metrics will be flat.
+* Hundreds of reads per peak → normal regime.
+* Thousands of reads per peak → ATAC/DNase-style; in this regime
+  the model is signal-limited, not data-limited.
+
+If your library is below the lower threshold, the cheapest fix is
+to pool replicates before peak calling and use the pooled BAM as
+the signal.
+
+
+CUDA out of memory at the start of training
+-------------------------------------------
+
+Symptom: ``torch.cuda.OutOfMemoryError`` in the first or second
+training step.
+
+The default training batch size (64) and input window (2114 bp) fit
+comfortably on a 16 GB GPU at the default 9-layer, 96-filter model.
+If you hit OOM, the fastest fixes:
+
+* Reduce ``fit_parameters.batch_size`` from 64 to 32 or 16.
+* Use bf16 autocast: set ``fit_parameters.dtype`` to ``"bfloat16"``.
+* Shrink the model: ``fit_parameters.n_filters`` from 96 to 64 or 48.
+
+GPU memory at training time is dominated by activations
+(``batch_size × in_window × n_filters × n_layers`` plus the
+``expansion``-wide MLP activations) and the optimizer state. Reducing
+``batch_size`` is the cheapest way to fit; reducing ``n_filters`` is
+the cheapest way to keep batch size high.
+
+
+The first iteration is very slow, then it speeds up
+---------------------------------------------------
+
+Symptom: the first training step takes tens of seconds; subsequent
+steps are fast.
+
+That is Triton autotune. The first call to each Triton kernel sweeps a
+list of (block size, num_warps, num_stages) configurations to find the
+best one, which takes wall time. Once autotune is done, the chosen
+configuration is cached for the process lifetime. There is nothing
+wrong; nothing to fix. The same is true on the first inference call
+(the inference megakernel autotunes separately).
+
+If you need to amortize this across runs you can pre-warm by running
+one batch through the model before timing anything you care about; see
+``bench_kernels.py`` in the repo for the pattern.
+
+
+Training loss is NaN
+--------------------
+
+Symptom: ``profile_loss`` or ``count_loss`` becomes ``nan`` partway
+through an epoch, or the validation metrics are ``nan``.
+
+The most common causes, in order:
+
+1. **A peak with zero counts**. The multinomial log-likelihood is
+   ``-inf`` when the true counts sum to zero across the entire output
+   window. :func:`cherimoya.io.PeakGenerator` filters peaks above
+   the 99th-percentile-by-1.2x ceiling but does not filter empty
+   peaks. Set ``fit_parameters.min_counts`` to a small positive
+   value (e.g. 5 or 10).
+2. **Mismatched strand counts**. If your signals are stranded but you
+   passed only one bigWig (or vice versa) the loaded ``y`` will have
+   the wrong shape. Verify by setting ``verbose=True`` and inspecting
+   the training-set and validation-set shapes printed at startup.
+3. **bf16 overflow in the count head**. If you use ``dtype="bfloat16"``
+   and the per-locus counts are very large, the log-counts loss can
+   overflow. Fall back to ``"float32"`` to confirm; if that fixes it,
+   either scale your signal down (``preprocessing_parameters.scale_factor``
+   when generating bigWigs) or cap with ``max_counts``.
+
+
+Training Pearson is stuck near zero
+-----------------------------------
+
+Symptom: validation count Pearson hovers at 0 or below for many
+epochs and never climbs.
+
+Things to check, in order:
+
+1. **You're passing the same signal as both training signal and
+   validation signal.** If they differ (e.g. by replicate), the model
+   is being asked to generalize across replicates, which is much
+   harder than generalizing across chromosomes.
+2. **Validation chromosomes contain no peaks.** Check the
+   ``Validation Set Size`` value printed at startup. If it's zero or
+   tiny, your ``validation_chroms`` don't intersect your peak file —
+   common when your peaks are subset to a single chromosome.
+3. **The signal really is uninformative.** Train on a known-good
+   ChIP-seq target (e.g. CTCF in K562 from ENCODE) as a control. If
+   that converges, the issue is upstream of Cherimoya.
+4. **You silently dropped controls.** If your trained-with-controls
+   model is being evaluated without ``X_ctl``, the count head sees
+   garbage and Pearson collapses. The evaluation step JSON must list
+   the same ``controls`` as the fit step.
+
+
+Pipeline cannot find a file
+---------------------------
+
+Symptom: ``FileNotFoundError: Pipeline cannot start; the following
+inputs are missing: ...`` from ``cherimoya pipeline``.
+
+The pre-flight check inside ``pipeline`` validates that every local
+input path exists before any expensive work starts. Remote paths
+(``http://``, ``https://``, ``s3://``, ``gs://``) are skipped because
+resolving them requires network access. If a path looks remote but
+isn't (e.g. a relative URL fragment), the check won't catch it.
+
+If the missing path is a file the pipeline is *supposed* to generate
+later in the run (e.g. you specified ``loci`` pointing at the not-yet
+called peak file), set the offending key to ``null`` instead and let
+the pipeline produce it.
+
+
+MACS3 hangs or returns no peaks
+-------------------------------
+
+Symptom: ``cherimoya pipeline`` sits on step 0.1 for a long time, or
+the resulting ``*_peaks.narrowPeak`` is empty.
+
+* If the BAM is large and you don't already have peaks, MACS3 itself
+  can take ~10 min on a typical ChIP-seq library. This is normal.
+* If the BAM is small and the resulting peak file is empty, your
+  ``callpeaks_q`` is too strict. Try 0.1 or 0.5 to see if any peaks
+  emerge; if so, your library is just shallow.
+* If the file format auto-detection picked wrong (e.g. ``BAM`` when
+  it should have been ``BAMPE``), set
+  ``preprocessing_parameters.callpeaks_format`` explicitly.
+
+
+bam2bw says "couldn't open" a remote URL
+----------------------------------------
+
+Symptom: ``bam2bw`` fails on an ``s3://`` or ``https://`` path.
+
+Cherimoya streams BAM/SAM and FASTA inputs through ``bam2bw`` /
+``tangermeme.io``. Streaming requires the remote storage to support
+range requests for the file type involved. Public HTTPS BAMs hosted
+on ENCODE, S3-presigned URLs, and standard GCS objects all work. If
+the remote path requires credentials, set them in your environment
+(``AWS_*`` for S3, ``GOOGLE_APPLICATION_CREDENTIALS`` for GCS) before
+running ``cherimoya pipeline``.
+
+
+``Cherimoya.load`` rejects a checkpoint
+---------------------------------------
+
+Symptom: ``Cherimoya.load("...torch")`` raises ``KeyError: 'config'``
+or ``RuntimeError`` about ``weights_only``.
+
+The checkpoint was saved with the legacy ``torch.save(model, ...)``
+pickle path that pre-dates v0.1.0 and is not loadable through the
+current config-plus-state-dict loader. Retrain from scratch with the
+current release.
+
+
+Loaded model gives different predictions than training did
+----------------------------------------------------------
+
+Symptom: at the last training-epoch validation, count Pearson was X;
+after ``Cherimoya.load`` it is materially different.
+
+The saved checkpoint contains the **EMA-applied** weights, not the
+running training weights. That is intentional and is what produces
+the best validation numbers during training. There is no mismatch to
+fix — the model you load is the correct one. Confirming: ``model.fit``
+applies the EMA shadow before saving, so the comparison should be
+against the *EMA* number printed in the training log, not the
+mid-epoch training-loss number.

--- a/docs/tutorials/attribution.rst
+++ b/docs/tutorials/attribution.rst
@@ -1,39 +1,43 @@
-Attribution & Motif Analysis
-============================
+Attribution and Motif Analysis
+==============================
 
-This tutorial covers how to calculate sequence attributions, identify important
-subsequences (seqlets), and discover motifs using TF-MoDISco.
+This tutorial covers per-base attribution, seqlet extraction, and
+TF-MoDISco motif discovery using a trained Cherimoya model.
+
+For ref/alt and per-variant scoring see :doc:`variant_effect`.
 
 
-What Are Attributions?
+What are attributions?
 ----------------------
 
-Attributions quantify how much each base pair in the input sequence contributes
-to the model's prediction. Cherimoya uses **saturation mutagenesis** — the
-effect of every possible single-nucleotide mutation — to compute importance
-scores.
+Attributions quantify how much each base in the input sequence
+contributes to the model's prediction. Cherimoya uses **saturation
+mutagenesis** — evaluating every single-nucleotide substitution and
+taking the predicted delta — to compute hypothetical importance
+scores. The output array has shape ``(n_examples, 4, window)``: one
+score per base per position.
 
-These scores can be used to:
+These scores are commonly used to:
 
-- Identify transcription factor binding sites
-- Discover de novo motifs
-- Understand regulatory grammar
+* identify transcription factor binding sites,
+* discover *de novo* motifs (via TF-MoDISco), and
+* understand regulatory grammar.
 
 
-Calculating Attributions via CLI
---------------------------------
+Computing attributions (CLI)
+----------------------------
 
 .. code-block:: bash
 
    cherimoya attribute -p attribute_params.json
 
-Example ``attribute_params.json``:
+Example JSON:
 
 .. code-block:: json
 
    {
        "model": "my_model.torch",
-       "sequences": "/path/to/hg38.fa",
+       "sequences": "hg38.fa",
        "loci": "peaks.narrowPeak",
        "chroms": ["chr2", "chr4", "chr5"],
        "output": "counts",
@@ -44,65 +48,88 @@ Example ``attribute_params.json``:
        "idx_filename": "attributions.idx.npy"
    }
 
-The ``output`` parameter controls what the attributions are calculated with
-respect to:
+``output`` controls what is being attributed to:
 
-- ``"counts"`` — attribute to total predicted counts (recommended for most
-  analyses)
-- ``"profile"`` — attribute to the predicted profile shape
+* ``"counts"`` — attribute to total predicted log-counts (recommended
+  for most analyses).
+* ``"profile"`` — attribute to the predicted profile shape (uses
+  ``ProfileWrapper`` from ``bpnetlite``).
+
+The CLI automatically:
+
+1. Loads sequences from ``loci`` on ``chroms`` and filters out any
+   example containing an ``N`` over the input window.
+2. Wraps the model with ``bpnetlite.bpnet.ControlWrapper`` (passing
+   zero controls if the model has none) and then with the chosen
+   output wrapper.
+3. Runs ``tangermeme.saturation_mutagenesis.saturation_mutagenesis``
+   over the central 400 bp of each input.
+4. Writes one-hot encoded inputs to ``ohe_filename``, hypothetical
+   importance scores to ``attr_filename``, and a boolean mask
+   (``idx_filename``) recording which loci survived the N-filter, so
+   that downstream stages can re-align the attribution rows back to
+   the original locus list.
+
+The ``.npz`` outputs store the array under key ``arr_0``
+(``numpy.savez_compressed`` default).
 
 
-Calculating Attributions via Python
------------------------------------
+Computing attributions (Python)
+-------------------------------
 
 .. code-block:: python
 
    import torch
-   from tangermeme.saturation_mutagenesis import saturation_mutagenesis
-   from bpnetlite.bpnet import ControlWrapper, CountWrapper
-
    from cherimoya import Cherimoya
+   from bpnetlite.bpnet import ControlWrapper, CountWrapper
+   from tangermeme.saturation_mutagenesis import saturation_mutagenesis
 
-   # Load model
    model = Cherimoya.load("my_model.torch", device="cuda")
 
-   # Wrap for count-based attribution
-   if model.n_control_tracks > 0:
-       model = ControlWrapper(model)
-   wrapper = CountWrapper(model)
+   # ControlWrapper wraps the model so that .forward(X) returns just the
+   # profile/counts tuple, supplying zero controls if the model has none.
+   model = ControlWrapper(model)
+   wrapper = CountWrapper(model)   # use ProfileWrapper(...) to attribute to profile shape
 
-   # Calculate attributions (hypothetical importance scores) over the
-   # central 400 bp window of each sequence.
-   mid = X_sequences.shape[-1] // 2
+   # ISM over the central 400 bp of each input sequence.
+   mid = X.shape[-1] // 2
    X_attr = saturation_mutagenesis(
-       wrapper, X_sequences,
+       wrapper, X,
        batch_size=512,
-       device='cuda',
+       device="cuda",
        hypothetical=True,
-       start=mid - 200,
-       end=mid + 200,
+       start=mid - 200, end=mid + 200,
    )
 
+This produces hypothetical importance scores. To get actual
+importance, multiply elementwise by the one-hot encoding and sum
+across the channel axis:
 
-Identifying Seqlets
+.. code-block:: python
+
+   importance = (X_attr * X[:, :, mid - 200:mid + 200]).sum(dim=1)
+
+
+Identifying seqlets
 -------------------
 
-Seqlets are contiguous subsequences with high attribution scores that likely
-correspond to functional elements like transcription factor binding motifs.
+Seqlets are contiguous subsequences with high attribution scores that
+likely correspond to functional elements — binding motifs, in
+practice. They are extracted via TF-MoDISco-style recursive seqlet
+calling on the (attribution × one-hot) signal.
 
-**Via CLI:**
+**CLI:**
 
 .. code-block:: bash
 
    cherimoya seqlets -p seqlet_params.json
 
-**Via Python:**
+**Python:**
 
 .. code-block:: python
 
    from tangermeme.seqlet import recursive_seqlets
 
-   # Combine one-hot encoding and attributions
    importance = (X_attr * X_ohe).sum(dim=1)
 
    seqlets = recursive_seqlets(
@@ -113,12 +140,35 @@ correspond to functional elements like transcription factor binding motifs.
        additional_flanks=3,
    )
 
+The default seqlet parameters mirror the CLI defaults (see
+:doc:`../cli`). After the recursive call, the CLI converts
+example-relative coordinates to genome coordinates using
+``tangermeme.utils.example_to_fasta_coords`` and writes a BED file.
 
-TF-MoDISco Motif Discovery
----------------------------
 
-TF-MoDISco groups similar seqlets into motif patterns. This is run
-automatically as part of the pipeline, or manually:
+tomtom-lite annotation
+----------------------
+
+When the pipeline JSON provides a ``motifs`` MEME file, the
+``pipeline`` subcommand additionally invokes ``ttl`` (tomtom-lite) on
+the seqlet BED to annotate each seqlet with its closest match against
+the motif database. This is what produces
+``{name}.seqlets_annotated.bed`` and ``{name}.motif_seqlet_count.tsv``.
+
+If you want to run this independently, the equivalent shell call is:
+
+.. code-block:: bash
+
+   ttl -f hg38.fa -b seqlets.bed \
+       -t JASPAR_2024.meme \
+       -s 100 -m 1000 -a 100 -c 250 -j -1 > seqlets_annotated.bed
+
+
+TF-MoDISco motif discovery
+--------------------------
+
+TF-MoDISco clusters seqlets into motif patterns. The pipeline runs
+this automatically; run it manually like so:
 
 .. code-block:: bash
 
@@ -133,22 +183,26 @@ automatically as part of the pipeline, or manually:
        -o modisco_report/ \
        -s ./
 
+The pipeline's TF-MoDISco step uses 100,000 seqlets by default
+(``modisco_motifs_parameters.n_seqlets``).
 
-Marginalization Experiments
----------------------------
 
-Marginalization experiments measure the causal effect of motif instances by
-inserting them into neutral backgrounds:
+Motif marginalization
+---------------------
+
+To quantify the *causal* effect of an inserted motif on the predicted
+profile and counts:
 
 .. code-block:: bash
 
    cherimoya marginalize -p marginalize_params.json
 
-This produces a report showing how each motif affects the predicted profile and
-counts when inserted into negative (non-peak) sequences.
+The output directory contains per-motif plots and a summary report
+showing how predictions change when each motif is inserted at the
+center of negative (non-peak) backgrounds.
 
 .. note::
 
-   Marginalization requires a motif database file in the MEME format. Most
-   databases will provide a file of this format. If you are looking for a
-   database to use, we recommend JASPAR2026.
+   Marginalization requires a motif database in MEME format. JASPAR
+   provides such files for many species; the latest as of writing is
+   JASPAR 2024.

--- a/docs/tutorials/cli_pipeline.rst
+++ b/docs/tutorials/cli_pipeline.rst
@@ -1,170 +1,173 @@
-CLI Pipeline Tutorial
-=====================
+CLI Pipeline Walkthrough
+========================
 
-This tutorial walks through using the Cherimoya command-line tool to run the
-full end-to-end pipeline from raw sequencing data to motif analysis.
+This page is the user's guide to the end-to-end Cherimoya CLI: how to
+take raw BAM/BED files and a reference genome through peak calling,
+training, attribution, seqlet calling, motif discovery, and motif
+marginalization in a single reproducible run.
+
+.. image:: ../../imgs/pipeline.png
+   :align: center
+   :width: 70%
+   :alt: Cherimoya end-to-end pipeline
+
+|
+
+For a complete list of every CLI flag, every JSON key, and every
+default value, see :doc:`../cli`. For assay-specific recipes
+(TF ChIP-seq, ATAC-seq, DNase-seq) see the recipe pages.
 
 
 Prerequisites
 -------------
 
-Before starting, make sure you have:
+You will need:
 
-- Cherimoya installed (see :doc:`../installation`)
-- A reference genome FASTA file (e.g., ``hg38.fa``)
-- Signal files (BAM, SAM, BED, or bigWig format)
-- (Optional) Control signal files
+- Cherimoya installed (see :doc:`../installation`).
+- A reference genome FASTA file (e.g. ``hg38.fa``).
+- One or more signal files (BAM/SAM, fragment BED/TSV, or bigWig).
+- A motif database in MEME format (optional, used by TF-MoDISco
+  reports and marginalization).
+- Optional: a BED of peak coordinates. If you don't provide one, the
+  pipeline calls peaks with MACS3.
+- Optional: BED of GC-matched negative regions. If you don't provide
+  one, the pipeline samples them automatically.
 
-
-Overview of CLI Commands
-------------------------
-
-.. list-table::
-   :header-rows: 1
-   :widths: 20 80
-
-   * - Command
-     - Description
-   * - ``negatives``
-     - Sample GC-content-matched negative regions
-   * - ``pipeline-json``
-     - Generate a pipeline configuration JSON file
-   * - ``fit``
-     - Train a Cherimoya model
-   * - ``evaluate``
-     - Evaluate a trained model
-   * - ``attribute``
-     - Calculate sequence attributions
-   * - ``seqlets``
-     - Identify important subsequences from attributions
-   * - ``marginalize``
-     - Run marginalization experiments for motifs
-   * - ``pipeline``
-     - Run the full end-to-end pipeline
-   * - ``batch``
-     - Run multiple pipelines in parallel
+All file inputs can be remote URLs (``http://``, ``https://``,
+``s3://``, ``gs://``). ``bam2bw`` streams the data directly without
+downloading the file first; the validation step before the run only
+checks paths that look local.
 
 
-Step 1: Generate a Pipeline Configuration
-------------------------------------------
+Subcommands at a glance
+-----------------------
 
-The pipeline is driven by a JSON configuration file. You can generate one using
-the ``pipeline-json`` command:
+The two commands you actually run, in the order you run them:
 
-.. code-block:: bash
+* ``cherimoya pipeline-json`` — emit a fully-populated JSON config
+  from a handful of CLI pointers.
+* ``cherimoya pipeline`` — run the full end-to-end pipeline from
+  that JSON.
 
-   cherimoya pipeline-json \
-       -s /path/to/hg38.fa \
-       -i /path/to/signal.bam \
-       -n my_ctcf_experiment \
-       -o ctcf.pipeline.json
+Every other subcommand (``fit``, ``evaluate``, ``attribute``,
+``seqlets``, ``marginalize``, ``negatives``, ``batch``) corresponds
+to an individual pipeline stage and can be run on its own. Each is
+driven by its own JSON, which the pipeline writes alongside its
+outputs. See :doc:`../cli` for the full subcommand reference.
 
-For stranded experiments with controls:
+
+Two-step workflow
+-----------------
+
+The expected workflow is two steps: generate a JSON, then run it.
+
+Step 1: generate a pipeline JSON
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For stranded ChIP-seq with input controls:
 
 .. code-block:: bash
 
    cherimoya pipeline-json \
-       -s /path/to/hg38.fa \
-       -i /path/to/treatment.bam \
-       -c /path/to/control.bam \
-       -n ctcf_stranded \
-       -o ctcf_stranded.pipeline.json
+       -s hg38.fa -p peaks.narrowPeak \
+       -i input1.bam -i input2.bam \
+       -c control1.bam -c control2.bam \
+       -m JASPAR_2024.meme -n my_experiment -o pipeline.json
 
-.. tip::
+For unstranded paired-end ATAC-seq with the standard +4 / -4 fragment
+shift:
 
-   Use ``-u`` for unstranded data and ``-f`` if your input consists of
-   fragment files rather than aligned reads.
+.. code-block:: bash
 
-.. tip::
+   cherimoya pipeline-json \
+       -s hg38.fa -p peaks.narrowPeak \
+       -i fragments.bam -m JASPAR_2024.meme \
+       -n atac_experiment -o pipeline.json \
+       -ps 4 -ns -4 -u -f -pe
 
-   If using ATAC-seq or DNase-seq data you may need to shift the reads.
-   Many packages use +4/-5 for ATAC-seq shifting, but the recommended shift
-   here is actually +4/-4. You can use -ps and -ns to shift your data but
-   make sure the original data is not shifted!
+Repeating ``-i`` adds another signal file. Repeating ``-c`` adds
+another control. Repeating ``-p`` adds another peak file. The full
+``pipeline-json`` flag list is in :doc:`../cli`.
+
+The resulting JSON has every parameter the pipeline uses, filled in
+from ``cherimoya_cli.defaults.default_pipeline_parameters``. You only
+need to edit the values you want to change from defaults; the runtime
+re-merges with defaults before each step.
+
+Step 2: edit and run
+~~~~~~~~~~~~~~~~~~~~
+
+Open the JSON and override any defaults — model width, training and
+validation chromosomes, seqlet p-value threshold, MoDISco settings,
+anything in the JSON.
+
+.. code-block:: bash
+
+   cherimoya pipeline -p pipeline.json
+
+What this does, in order:
+
+1. **MACS3 peak calling** (skipped if ``loci`` is set).
+2. **bam2bw conversion** to bigWig (skipped if signals are already
+   bigWigs).
+3. **GC-matched negative sampling** (skipped if ``negatives`` is set).
+4. **Model training** — writes ``{name}.torch`` (best checkpoint by
+   validation count Pearson) and ``{name}.final.torch`` (EMA weights
+   at end of training), plus ``{name}.log``.
+5. **Attribution** via saturation mutagenesis over the central 400 bp
+   of each example, saved as ``{name}.attributions.{ohe,attr}.npz``
+   and ``{name}.attributions.idxs.npy``.
+6. **Seqlet identification** with TF-MoDISco-style recursive seqlet
+   calling on the (attribution × one-hot) signal, written to
+   ``{name}.seqlets.bed``.
+7. **tomtom-lite seqlet annotation** against the motif database, if
+   ``motifs`` was provided; results in
+   ``{name}.seqlets_annotated.bed`` and a counts table in
+   ``{name}.motif_seqlet_count.tsv``.
+8. **TF-MoDISco motif discovery** and HTML report; results in
+   ``{name}_modisco_results.h5`` and ``{name}_modisco/``.
+9. **Marginalization** — measures the predicted effect of inserting
+   each motif into negative backgrounds. Output in
+   ``{name}_marginalize/``.
+
+Each sub-step writes its own JSON snapshot
+(``{name}.fit.json``, ``{name}.attribute.json``, …) so individual
+stages can be re-run in isolation, and pre-existing snapshots can be
+edited and re-run if you only need to change one stage.
 
 
-Step 2: Customize the Parameters (Optional)
---------------------------------------------
-
-Open the generated JSON file and adjust parameters as needed. Key parameters
-include:
-
-.. code-block:: json
-
-   {
-       "fit_parameters": {
-           "n_filters": 64,
-           "n_layers": 9,
-           "max_epochs": 50,
-           "lr": 0.004,
-           "batch_size": 512,
-           "max_jitter": 500,
-           "early_stopping": 15
-       }
-   }
-
-.. note::
-
-   The pipeline will automatically call peaks with MACS3, convert BAMs to
-   bigWigs, and generate GC-matched negatives if these are not explicitly
-   provided in the JSON.
-
-
-Step 3: Run the Pipeline
+Running individual steps
 ------------------------
 
-.. code-block:: bash
-
-   cherimoya pipeline -p ctcf.pipeline.json
-
-The pipeline will execute the following steps in order:
-
-1. **Peak calling** (if ``loci`` is not provided) — uses MACS3
-2. **Data conversion** (if signal files are BAMs) — uses bam2bw
-3. **Negative sampling** (if ``negatives`` is not provided) — GC-matched
-4. **Model training** — trains a Cherimoya model with dual optimizers
-5. **Attribution calculation** — saturation mutagenesis on validation chroms
-6. **Seqlet identification** — extract important subsequences
-7. **TF-MoDISco** — motif discovery and report generation
-8. **Marginalization** — motif effect size estimation
-
-
-Running Individual Steps
-------------------------
-
-You can also run steps individually using their respective JSON configuration
-files.
-
-**Training:**
+Each stage has its own subcommand and JSON schema. You can run them
+directly:
 
 .. code-block:: bash
 
-   cherimoya fit -p fit_parameters.json
+   cherimoya fit -p my_experiment.fit.json
+   cherimoya evaluate -p my_experiment.evaluate.json
+   cherimoya attribute -p my_experiment.attribute.json
+   cherimoya seqlets -p my_experiment.seqlets.json
+   cherimoya marginalize -p my_experiment.marginalize.json
 
-**Evaluation:**
+The defaults for each command are in
+``cherimoya_cli.defaults.default_*_parameters``; the merged JSON
+snapshots written by ``pipeline`` make them concrete.
+
+Every step JSON also supports ``"skip": true`` to no-op that step.
+
+
+Batch mode
+----------
+
+For training the same configuration across many datasets in parallel
+on multiple GPUs:
 
 .. code-block:: bash
 
-   cherimoya evaluate -p evaluate_parameters.json
+   cherimoya batch -p batch.json
 
-**Attribution:**
-
-.. code-block:: bash
-
-   cherimoya attribute -p attribute_parameters.json
-
-
-Batch Processing
-----------------
-
-To train models on many datasets in parallel, use the ``batch`` command:
-
-.. code-block:: bash
-
-   cherimoya batch -p batch_parameters.json
-
-The batch command will automatically distribute jobs across available GPUs.
-Use ``"device": "*"`` in the JSON to auto-detect all available CUDA devices.
+Minimal ``batch.json``:
 
 .. code-block:: json
 
@@ -175,5 +178,137 @@ Use ``"device": "*"`` in the JSON to auto-detect all available CUDA devices.
        "sequences": "/path/to/hg38.fa"
    }
 
-When ``signals`` contains a glob pattern and ``name`` is null, names are
-automatically derived from the signal filenames.
+Behavior:
+
+* ``"device": "*"`` is expanded to the full list of available CUDA
+  devices (``cuda:0``, ``cuda:1``, …).
+* When ``"signals"`` is a glob and ``"name"`` is ``null``, names are
+  derived from the signal filenames automatically.
+* Each derived job is written to its own ``{name}.pipeline.json`` and
+  run via ``cherimoya pipeline``. Joblib distributes jobs round-robin
+  across the device list.
+
+To use batch mode with custom names or paired-up controls/loci/negatives,
+provide same-length lists in those fields; element ``i`` is consumed by
+job ``i``.
+
+
+About bam2bw
+------------
+
+The pipeline does not call BAM/SAM/fragment files directly into the
+training step — it converts them to bigWig first using the
+``bam2bw`` tool, which is a hard dependency. ``bam2bw`` streams the
+input (local or remote URL), counts reads or fragments into per-base
+coverage, optionally applies a ± shift (used for Tn5 / DNase
+corrections), and emits one bigWig (unstranded) or two bigWigs
+(``+`` / ``-`` stranded).
+
+This conversion is what enables remote URLs as inputs: ``bam2bw``
+fetches reads via byte-range requests rather than downloading the
+whole file. The resulting bigWigs are written into the working
+directory and re-used by every downstream stage.
+
+If your signals are already bigWigs, the pipeline skips this step
+automatically. To use ``bam2bw`` standalone (outside the pipeline),
+invoke it directly — see its own documentation.
+
+
+Calling negatives independently
+-------------------------------
+
+``cherimoya pipeline`` calls negatives for you when the JSON's
+``negatives`` field is null. If you want to sample GC-matched
+negatives without running the full pipeline (e.g. you're going to
+train a non-Cherimoya model on the same regions), use the
+``negatives`` subcommand:
+
+.. code-block:: bash
+
+   cherimoya negatives \
+       -i peaks.narrowPeak \
+       -f hg38.fa \
+       -b signal.bw \
+       -o negatives.bed \
+       --bin_width 0.02 --max_n_perc 0.1 --beta 0.5
+
+The output is a 3-column BED of regions matched by GC content to the
+input peaks, with at most ``--max_n_perc`` fraction of ``N`` bases
+and (optionally) signal below ``--beta × min(peak_counts)``.
+
+
+Running on a non-hg38 reference
+-------------------------------
+
+The defaults assume hg38. To run on a different reference (mouse mm10,
+non-human, or a different hg version), override three keys in the
+pipeline JSON:
+
+* ``fit_parameters.training_chroms`` — chromosomes used to train.
+  Replace with the appropriate list for your reference (e.g. mm10:
+  ``["chr1", "chr2", …, "chr19", "chrX", "chrY"]`` minus the two
+  validation chromosomes you choose).
+* ``fit_parameters.validation_chroms`` — held-out chromosomes for
+  validation. Two chromosomes is enough.
+* ``preprocessing_parameters.callpeaks_gsize`` — MACS3 effective
+  genome size. Use ``"mm"`` for mouse, ``"ce"`` for *C. elegans*,
+  ``"dm"`` for fly, or a numeric value (e.g. ``"2.7e9"`` for hg38) for
+  any other organism.
+
+For non-chromosome reference contigs (scaffolds, alternate
+haplotypes, viral integrations), exclude them by listing them
+explicitly in the training/validation chromosome lists, or by passing
+an ``exclusion_lists`` BED.
+
+
+Outputs
+-------
+
+A successful pipeline run leaves the following in the working
+directory (with ``{name}`` from the ``-n`` flag in step 1):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 50 50
+
+   * - File
+     - Contents
+   * - ``{name}.torch``
+     - Best-by-validation-count-Pearson checkpoint (config + state_dict).
+   * - ``{name}.final.torch``
+     - Final EMA-applied checkpoint at end of training.
+   * - ``{name}.log``
+     - Per-epoch training and validation metrics (TSV).
+   * - ``{name}.performance.tsv``
+     - Final held-out chromosome metrics (single row TSV).
+   * - ``{name}.+.bw`` / ``{name}.-.bw``
+     - bigWigs produced by ``bam2bw`` for the stranded signal.
+   * - ``{name}.bw``
+     - bigWig produced by ``bam2bw`` for unstranded signal.
+   * - ``{name}.control.{+,-}.bw``
+     - bigWigs produced by ``bam2bw`` for stranded controls.
+   * - ``{name}_peaks.narrowPeak``
+     - Peaks called by MACS3 (when ``loci`` not provided).
+   * - ``{name}.negatives.bed``
+     - GC-matched negative regions (when ``negatives`` not provided).
+   * - ``{name}.attributions.ohe.npz``
+     - One-hot encoded sequences over the central 400 bp window.
+   * - ``{name}.attributions.attr.npz``
+     - Hypothetical importance scores (saturation mutagenesis).
+   * - ``{name}.attributions.idxs.npy``
+     - Boolean mask into the original loci list selecting examples
+       that had no Ns over the window.
+   * - ``{name}.seqlets.bed``
+     - Recursive seqlets in genome coordinates.
+   * - ``{name}.seqlets_annotated.bed``
+     - Seqlets with closest-motif annotation from tomtom-lite.
+   * - ``{name}.motif_seqlet_count.tsv``
+     - Count of seqlets matched per motif.
+   * - ``{name}_modisco_results.h5``
+     - TF-MoDISco pattern HDF5.
+   * - ``{name}_modisco/``
+     - TF-MoDISco HTML report.
+   * - ``{name}_marginalize/``
+     - Motif marginalization report (HTML plus CSVs).
+   * - ``{name}.{pipeline,fit,evaluate,attribute,seqlets,marginalize}.json``
+     - Per-step JSON snapshots of the actual parameters used.

--- a/docs/tutorials/python_api.rst
+++ b/docs/tutorials/python_api.rst
@@ -1,33 +1,37 @@
 Python API Tutorial
 ===================
 
-This tutorial demonstrates how to use the Cherimoya Python API to train a
-model, make predictions, and evaluate performance.
+This tutorial shows how to use the Cherimoya Python API to build a
+model, train it, and generate predictions. For attribution, motif
+analysis, and variant effect prediction see the dedicated tutorials.
 
 
-Creating a Model
+Creating a model
 ----------------
 
-A Cherimoya model is a standard ``torch.nn.Module``:
+``Cherimoya`` is a ``torch.nn.Module``:
 
 .. code-block:: python
 
    from cherimoya import Cherimoya
 
    model = Cherimoya(
-       n_filters=96,           # Width of the convolutional backbone (default 96)
-       n_layers=9,             # Number of Cheri Blocks (dilation: 1, 2, ..., 256)
-       n_outputs=2,            # Output tracks (2 for stranded data)
-       n_control_tracks=0,     # Control input tracks (0 if no controls)
-       expansion=2,            # MLP expansion factor inside each Cheri Block (default 2)
-       residual_scale=0.15,    # Fixed scalar on each residual connection (default 0.15)
-       single_count_output=True,  # Single scalar count vs. per-track counts
-       name="my_model",        # Model name (used for save filenames)
+       n_filters=96,              # backbone width
+       n_layers=9,                # number of Cheri Blocks (dilations 1, 2, ..., 256)
+       n_outputs=2,               # number of profile output tracks (e.g. 2 for stranded)
+       n_control_tracks=0,        # number of control input tracks
+       expansion=2,               # MLP expansion factor inside each Cheri Block
+       residual_scale=0.15,       # fixed residual scale
+       single_count_output=True,  # single scalar count vs. one count per track
+       name="my_model",           # used for save filenames
    ).cuda()
 
+The full constructor signature, including ``trimming`` and
+``verbose``, is in :doc:`../api/model`.
 
-Understanding the Input/Output Shapes
---------------------------------------
+
+Input/output shapes
+-------------------
 
 .. list-table::
    :header-rows: 1
@@ -37,78 +41,83 @@ Understanding the Input/Output Shapes
      - Shape
      - Description
    * - ``X`` (input)
-     - ``(batch, 4, in_window)``
-     - One-hot encoded DNA sequence
+     - ``(N, 4, in_window)``
+     - One-hot encoded DNA over the input window. ``in_window`` is
+       2114 by default.
    * - ``X_ctl`` (optional)
-     - ``(batch, n_control, in_window)``
-     - Control signal per position
+     - ``(N, n_control_tracks, in_window)``
+     - Per-position control signal. Pass ``None`` when ``n_control_tracks
+       == 0``.
    * - ``y_profile`` (output)
-     - ``(batch, n_outputs, out_window)``
-     - Predicted profile logits
+     - ``(N, n_outputs, out_window)``
+     - Predicted profile logits. ``out_window`` is 1000 by default.
    * - ``y_counts`` (output)
-     - ``(batch, n_count_outputs)``
-     - Predicted log counts
+     - ``(N, n_count_outputs)``
+     - Predicted log counts. ``n_count_outputs`` is 1 if
+       ``single_count_output`` else ``n_outputs``.
 
-The default ``in_window`` is 2114 bp and ``out_window`` is 1000 bp. The
-difference (``trimming = (2114 - 1000) / 2 = 557``) accounts for the receptive
-field of the dilated convolution stack.
+By default ``trimming = 46 + sum(2**i for i in range(n_layers))``,
+which is 557 for the default 9-layer model and gives the 2114 → 1000
+window pair.
 
 
-Loading Training Data
+Loading training data
 ---------------------
 
-The :func:`~cherimoya.io.PeakGenerator` function handles all data I/O:
+:func:`cherimoya.io.PeakGenerator` reads peaks, negatives, sequences,
+and signal/control bigWigs, applies filtering and jitter, and returns
+a ``torch.utils.data.DataLoader``:
 
 .. code-block:: python
 
    from cherimoya.io import PeakGenerator
 
    training_data = PeakGenerator(
-       peaks="peaks.narrowPeak",         # Peak regions (BED/narrowPeak)
-       negatives="negatives.bed",        # GC-matched negative regions
-       sequences="hg38.fa",             # Reference genome
-       signals=["signal.+.bw", "signal.-.bw"],  # Signal tracks
-       controls=None,                    # Control tracks (or list of bigWigs)
-       chroms=["chr2", "chr4", "chr5"],  # Training chromosomes
+       peaks="peaks.narrowPeak",
+       negatives="negatives.bed",
+       sequences="hg38.fa",
+       signals=["signal.+.bw", "signal.-.bw"],
+       controls=None,                       # or list of bigWigs
+       chroms=["chr2", "chr4", "chr5"],     # training chromosomes
        in_window=2114,
        out_window=1000,
-       max_jitter=128,                   # Random position jitter (bp)
-       negative_ratio=0.1,              # Ratio of negatives to peaks
-       reverse_complement=True,          # Augment with reverse complements
+       max_jitter=50,                       # peak-center jitter at training time
+       negative_ratio=0.1,                  # n_negatives per n_peaks per epoch
+       reverse_complement=True,             # augment with reverse complements
        batch_size=64,
-       num_workers=1,                    # Async prefetch workers
-       random_state=0,                   # Sampler seed (reproducible)
+       num_workers=1,                       # async prefetch workers
+       random_state=0,                      # base seed; reproducible
+       verbose=True,                        # print progress and filter counts
    )
 
-.. tip::
+Setting ``verbose=True`` prints per-step counts of filtered peaks and
+filtered negatives, which is the easiest way to verify the loader is
+seeing the data you expect.
 
-   Use ``verbose=True`` to see progress bars during data loading and summary
-   statistics about the number of peaks, negatives, and filtered regions.
 
+Reproducible sampling
+~~~~~~~~~~~~~~~~~~~~~
 
-Sampling Strategy
-^^^^^^^^^^^^^^^^^
-
-The underlying :class:`~cherimoya.io.PeakNegativeSampler` is fully
+The underlying :class:`cherimoya.io.PeakNegativeSampler` is fully
 deterministic given ``random_state``. ``__getitem__(idx)`` is a pure
 function of ``idx`` and the current epoch, with no dependence on call
-history. As a consequence:
+history.
 
-- Each epoch yields exactly ``n_peaks + int(n_peaks * negative_ratio)``
+* Each epoch yields exactly ``n_peaks + int(n_peaks * negative_ratio)``
   examples; every peak appears exactly once and the peak/negative
-  interleaving is random but reproducible.
-- Setting ``num_workers > 1`` produces the **same** sequence of batches
-  as ``num_workers = 1`` — just faster. All workers compute the same
-  data for any given index.
-- Per-position augmentations (jitter, reverse-complement) are also
-  drawn from the per-epoch RNG, so two runs with the same seed produce
-  bit-identical training data.
+  interleaving is reproducible.
+* Setting ``num_workers > 1`` produces the *same* sequence of batches
+  as ``num_workers = 1``, just faster.
+* Per-position jitter and reverse-complement flips are drawn from the
+  per-epoch RNG, so two runs with the same seed produce bit-identical
+  training data.
 
 
-Preparing Validation Data
---------------------------
+Preparing validation data
+-------------------------
 
-Validation data is loaded as a single block of tensors:
+Validation data is loaded as a single block of tensors using
+``tangermeme.io.extract_loci``:
 
 .. code-block:: python
 
@@ -118,33 +127,32 @@ Validation data is loaded as a single block of tensors:
        sequences="hg38.fa",
        signals=["signal.+.bw", "signal.-.bw"],
        loci="peaks.narrowPeak",
-       chroms=["chr8", "chr20"],  # Held-out validation chromosomes
+       chroms=["chr8", "chr20"],
        in_window=2114,
        out_window=1000,
-       max_jitter=0,              # No jitter for validation
-       ignore=list('QWERYUIOPSDFHJKLZXVBNM'),  # Ignore non-standard chroms
+       max_jitter=0,
+       ignore=list('QWERYUIOPSDFHJKLZXVBNM'),
    )
 
-   X_valid, y_valid = valid_data  # Without controls
-   # X_valid, y_valid, X_ctl_valid = valid_data  # With controls
+   X_valid, y_valid = valid_data
+   # X_valid, y_valid, X_ctl_valid = valid_data   # with controls
 
 
-Setting Up Optimizers
----------------------
+Optimizers and schedulers
+-------------------------
 
-Cherimoya uses a dual-optimizer strategy — **Muon** for 2D projection layers
-and **AdamW** for everything else:
+Cherimoya uses a dual-optimizer strategy: Muon for 2D projection
+weights in the Cheri Blocks, AdamW for everything else. To match the
+CLI defaults exactly:
 
 .. code-block:: python
 
    from torch.optim import AdamW, Muon
-   from torch.optim.lr_scheduler import (
-       LinearLR, CosineAnnealingLR, SequentialLR
-   )
+   from torch.optim.lr_scheduler import LinearLR, CosineAnnealingLR, SequentialLR
 
-   # Route parameters to the appropriate optimizer, with Muon only handling
-   # internal 2D matrices and leaving all other parameters, including the
-   # head and tail layers, to AdamW
+   # Route parameters. Muon takes the 2D weights inside Cheri Blocks
+   # (linear1.weight and linear2.weight); AdamW takes everything else,
+   # including the count-head linear layer (name == "linear.weight").
    muon_params, adam_params = [], []
    for name, p in model.named_parameters():
        if p.ndim == 2 and "weight" in name and name != "linear.weight":
@@ -152,27 +160,27 @@ and **AdamW** for everything else:
        else:
            adam_params.append(p)
 
-   # Create optimizers
-   muon_optimizer = Muon(muon_params, lr=0.01, weight_decay=0.0)
-   adam_optimizer = AdamW(adam_params, lr=0.004, weight_decay=0.0)
+   muon_optimizer = Muon(muon_params, lr=0.025, weight_decay=0.01)
+   adam_optimizer = AdamW(adam_params, lr=0.004, weight_decay=0.2)
 
-   # Warmup + cosine decay schedules
-   n_warmup_iters = len(training_data) * 5      # 5 epoch warmup
-   n_total_iters = len(training_data) * 50       # 50 total epochs
+   # Warmup for 5 epochs, then cosine decay for the rest of training
+   # down to eta_min=1e-5. Note T_max uses (max_epochs - 5), not max_epochs.
+   max_epochs = 50
+   num_warmup_epochs = 5
+   num_warmup_iters = len(training_data) * num_warmup_epochs
+   num_decay_iters = len(training_data) * max(1, max_epochs - num_warmup_epochs)
 
-   muon_scheduler = SequentialLR(muon_optimizer, schedulers=[
-       LinearLR(muon_optimizer, start_factor=0.01, total_iters=n_warmup_iters),
-       CosineAnnealingLR(muon_optimizer, T_max=n_total_iters, eta_min=1e-5),
-   ], milestones=[n_warmup_iters])
+   def make_scheduler(opt):
+       warm = LinearLR(opt, start_factor=0.01, total_iters=num_warmup_iters)
+       cos = CosineAnnealingLR(opt, T_max=num_decay_iters, eta_min=1e-5)
+       return SequentialLR(opt, schedulers=[warm, cos], milestones=[num_warmup_iters])
 
-   adam_scheduler = SequentialLR(adam_optimizer, schedulers=[
-       LinearLR(adam_optimizer, start_factor=0.01, total_iters=n_warmup_iters),
-       CosineAnnealingLR(adam_optimizer, T_max=n_total_iters, eta_min=1e-5),
-   ], milestones=[n_warmup_iters])
+   muon_scheduler = make_scheduler(muon_optimizer)
+   adam_scheduler = make_scheduler(adam_optimizer)
 
 
-Training the Model
-------------------
+Training
+--------
 
 .. code-block:: python
 
@@ -181,59 +189,51 @@ Training the Model
        muon_optimizer, adam_optimizer,
        muon_scheduler, adam_scheduler,
        X_valid=X_valid,
-       X_ctl_valid=None,    # Pass control tensors here if using controls
+       X_ctl_valid=None,            # pass control tensors here if using controls
        y_valid=y_valid,
        max_epochs=50,
        batch_size=64,
-       early_stopping=15,   # Stop after 15 epochs without improvement
-       dtype='float32',     # Or 'bfloat16' for mixed precision
+       early_stopping=15,           # stop after 15 epochs without count-Pearson gain
+       dtype='float32',             # or 'bfloat16' for mixed precision via autocast
        device='cuda',
    )
 
-During training, the model saves:
+What ``fit`` does internally:
 
-- ``my_model.torch`` — best model checkpoint
-- ``my_model.final.torch`` — final model after training
-- ``my_model.log`` — training/validation metrics log
+* Maintains an :class:`~cherimoya.cherimoya.EMA` shadow of every
+  floating-point parameter (decay 0.999). The shadow is updated after
+  every optimizer step.
+* Runs the training step with ``torch.autocast`` using ``dtype``.
+* Validates at the end of each epoch using the EMA-applied weights;
+  the validation Pearson correlation on counts is the metric used for
+  best-checkpoint selection.
+* Saves ``{model.name}.torch`` whenever validation count Pearson
+  improves, and ``{model.name}.final.torch`` at the very end (also
+  with EMA weights applied).
+* Saves ``{model.name}.log`` with the training and validation metrics
+  per epoch.
+
+Once the gradients on ``lw0`` (the profile loss-weight scalar) become
+small at the end of an epoch, both loss-weight scalars are frozen and
+the loss reduces to a fixed weighted sum for the rest of training.
 
 
-Saving and Loading Models
--------------------------
+Saving and loading
+------------------
 
-Cherimoya checkpoints store the constructor arguments next to the parameter
-state dict. This makes loading robust to package layout changes and lets the
-checkpoint be loaded with PyTorch's ``weights_only=True`` setting.
-
-**Saving**:
+See :doc:`save_load` for the full discussion. Briefly:
 
 .. code-block:: python
 
-   from cherimoya import Cherimoya
-
-   model = Cherimoya(n_filters=96, n_layers=9, n_outputs=2)
-   # ... train ...
    model.save("my_model.torch")
-
-**Loading**:
-
-.. code-block:: python
-
-   from cherimoya import Cherimoya
-
-   # Load to CPU (default) — fine for inspection or CPU-only inference.
-   model = Cherimoya.load("my_model.torch")
-
-   # Load directly onto GPU.
    model = Cherimoya.load("my_model.torch", device="cuda")
 
-The checkpoint is a dictionary with two keys, ``config`` (the kwargs
-passed to ``Cherimoya.__init__``) and ``state_dict`` (the parameter
-tensors). Older checkpoints saved with ``torch.save(model, ...)`` are not
-compatible with this loader and should be retrained or migrated.
 
-
-Making Predictions
+Making predictions
 ------------------
+
+For evaluation use the standard ``tangermeme.predict`` helper, which
+batches the input and concatenates the outputs:
 
 .. code-block:: python
 
@@ -247,7 +247,8 @@ Making Predictions
        dtype='float32',
    )
 
-For reverse-complement averaging (often improves performance):
+Reverse-complement averaging often improves performance and is what
+the ``evaluate`` CLI uses when ``reverse_complement_average`` is set:
 
 .. code-block:: python
 
@@ -257,13 +258,16 @@ For reverse-complement averaging (often improves performance):
        model, torch.flip(X_test, dims=(-1, -2)),
        batch_size=64, device='cuda',
    )
-
    y_profile_avg = (y_profile + torch.flip(y_profile_rc, dims=(-1, -2))) / 2
    y_counts_avg = (y_counts + y_counts_rc) / 2
 
 
-Evaluating Performance
+Evaluating performance
 ----------------------
+
+:func:`cherimoya.performance.calculate_performance_measures` computes
+profile and counts metrics. It takes predicted logits, observed
+counts, and predicted log counts, and returns a dict of tensors:
 
 .. code-block:: python
 
@@ -275,4 +279,50 @@ Evaluating Performance
    )
 
    for name, values in measures.items():
-       print(f"{name}: {values.mean():.4f}")
+       print(f"{name}: {values.mean().item():.4f}")
+
+If ``measures`` is ``None`` (the default), all built-in measures are
+computed. The full list and signature is in :doc:`../api/performance`.
+
+
+Interpreting the metrics
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Rough ballparks from typical ChIP-seq and ATAC-seq experiments,
+useful for sanity-checking a trained model:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 35 35
+
+   * - Metric
+     - Usable
+     - Strong
+   * - ``count_pearson``
+     - ≥ 0.5
+     - ≥ 0.7
+   * - ``profile_pearson``
+     - ≥ 0.3
+     - ≥ 0.5
+   * - ``profile_jsd``
+     - ≤ 0.5
+     - ≤ 0.3
+   * - ``profile_mnll``
+     - context-dependent — compare to baseline
+     - context-dependent
+
+Notes:
+
+* Count Pearson is computed across the held-out set as a single
+  scalar (one correlation across all examples), so it is sensitive
+  to dynamic range. Datasets with a wider distribution of peak
+  heights produce higher count Pearson at fixed model quality;
+  comparing count Pearson across datasets is not apples-to-apples.
+* Profile Pearson and JSD are per-example and then averaged, so
+  they're more comparable across datasets but noisier per example.
+* ``count_pearson`` near zero is almost always a sign of a setup
+  problem (see :doc:`../troubleshooting`); a well-trained model on
+  real data essentially never lands there.
+* When training with controls, omitting ``controls`` at evaluation
+  collapses ``count_pearson`` — the count head sees the wrong
+  feature distribution.

--- a/docs/tutorials/save_load.rst
+++ b/docs/tutorials/save_load.rst
@@ -1,0 +1,98 @@
+Saving and Loading Models
+=========================
+
+Cherimoya checkpoints store the constructor arguments next to the
+parameter state dict. This format is robust to source-layout changes
+and is safe to load with PyTorch's ``weights_only=True`` flag, which
+the loader uses by default.
+
+
+Saving
+------
+
+.. code-block:: python
+
+   from cherimoya import Cherimoya
+
+   model = Cherimoya(n_filters=96, n_layers=9, n_outputs=1)
+   # ... train ...
+   model.save("my_model.torch")
+
+The saved payload is a dict with two keys:
+
+* ``config`` — the kwargs needed to reconstruct the model (every
+  argument to ``Cherimoya.__init__``).
+* ``state_dict`` — the parameter tensors.
+
+The ``CheriBlock._w_cache`` (bf16 cast cache used by the inference
+megakernel) is intentionally not part of the state dict and is not
+saved. It is rebuilt on the next forward pass.
+
+
+Loading
+-------
+
+.. code-block:: python
+
+   from cherimoya import Cherimoya
+
+   # CPU by default — fine for inspection or CPU-only inference.
+   model = Cherimoya.load("my_model.torch")
+
+   # Or load directly onto a GPU:
+   model = Cherimoya.load("my_model.torch", device="cuda")
+
+.. important::
+
+   The weights inside a checkpoint are the **EMA snapshot**, not the
+   running training weights. ``model.fit`` applies the EMA shadow
+   before every save, both for the best-by-validation checkpoint and
+   the final-epoch checkpoint. This is what produces the smoothed
+   validation numbers reported in the training log; the model you
+   load and use at inference is the same one those numbers describe.
+
+The loader:
+
+1. Reads the payload with ``torch.load(..., weights_only=True)``.
+2. Reconstructs the module via ``Cherimoya(**payload['config'])``.
+3. Calls ``load_state_dict`` with the saved state dict.
+4. Moves the module to ``device`` before returning.
+
+Because ``load_state_dict`` writes through ``data.copy_``, the
+``_version`` counter on each parameter bumps and the inference
+megakernel's weight cache invalidates automatically on the next
+forward pass.
+
+
+Best-of and final checkpoints
+-----------------------------
+
+``model.fit(...)`` writes two checkpoint files:
+
+* ``{model.name}.torch`` — the best checkpoint observed during
+  training, selected by validation count Pearson correlation. Saved
+  after EMA weights are applied.
+* ``{model.name}.final.torch`` — the model at the very end of
+  training, also with EMA weights applied.
+
+Both are produced via ``model.save(...)`` and are loadable with
+``Cherimoya.load(...)``.
+
+The ``.log`` file emitted alongside the checkpoints is a plain TSV
+with one row per epoch. It is not used by the loader; it is for your
+own inspection.
+
+
+Compatibility
+-------------
+
+Checkpoints saved with the v0.1.0+ ``model.save`` format are forward-
+and backward-compatible across point releases as long as the
+constructor signature does not change. The version of Cherimoya you
+trained with is recorded implicitly by the keys in the ``config``
+dict — if you later add or rename a constructor argument, you may
+need to map old keys to new ones before loading.
+
+The pinned-version warning in the README is about this: if a future
+release renames a constructor argument, an older checkpoint will
+fail to load until you do the mapping.

--- a/docs/tutorials/variant_effect.rst
+++ b/docs/tutorials/variant_effect.rst
@@ -1,0 +1,140 @@
+Variant Effect Prediction
+=========================
+
+Cherimoya predicts a base-pair-resolution profile and total counts
+from sequence alone, so quantifying the predicted effect of a variant
+reduces to running the model on the reference and alternate sequences
+and comparing the outputs. This page documents the common patterns,
+both from the CLI and from Python.
+
+
+Saturation mutagenesis (CLI)
+----------------------------
+
+The simplest *exhaustive* variant scan is the ``attribute`` subcommand,
+which performs in-silico saturation mutagenesis over the central 400 bp
+of each input sequence — every possible single-nucleotide substitution,
+scored by its effect on the predicted log counts (or profile):
+
+.. code-block:: bash
+
+   cherimoya attribute -p attribute_params.json
+
+Example JSON:
+
+.. code-block:: json
+
+   {
+       "model": "my_model.torch",
+       "sequences": "hg38.fa",
+       "loci": "peaks.narrowPeak",
+       "chroms": ["chr2", "chr4", "chr5"],
+       "output": "counts",
+       "batch_size": 512,
+       "device": "cuda",
+       "ohe_filename": "attributions.ohe.npz",
+       "attr_filename": "attributions.attr.npz",
+       "idx_filename": "attributions.idx.npy"
+   }
+
+``output`` can be ``"counts"`` (recommended for most analyses) or
+``"profile"``. The output array has shape ``(n_examples, 4, 400)`` and
+contains hypothetical importance scores per base per channel —
+equivalent to the predicted delta when substituting that nucleotide at
+that position.
+
+This is the CLI equivalent of running ``tangermeme.saturation_mutagenesis``
+on each locus.
+
+
+Single-prediction inference (Python)
+------------------------------------
+
+For a one-off prediction at a single sequence (e.g. ref vs alt), use
+``tangermeme.predict.predict``:
+
+.. code-block:: python
+
+   import torch
+   from cherimoya import Cherimoya
+   from tangermeme.predict import predict
+
+   model = Cherimoya.load("my_model.torch", device="cuda")
+   model.eval()
+
+   # X_ref, X_alt: (N, 4, 2114) one-hot tensors.
+   y_profile_ref, y_counts_ref = predict(model, X_ref, batch_size=64, device="cuda")
+   y_profile_alt, y_counts_alt = predict(model, X_alt, batch_size=64, device="cuda")
+
+   delta_counts = y_counts_alt - y_counts_ref
+
+
+Exhaustive ISM (Python)
+-----------------------
+
+For an in-silico saturation mutagenesis sweep over a region, use
+``tangermeme.saturation_mutagenesis.saturation_mutagenesis``:
+
+.. code-block:: python
+
+   import torch
+   from cherimoya import Cherimoya
+   from tangermeme.saturation_mutagenesis import saturation_mutagenesis
+   from bpnetlite.bpnet import ControlWrapper, CountWrapper
+
+   model = Cherimoya.load("my_model.torch", device="cuda")
+   if model.n_control_tracks > 0:
+       model = ControlWrapper(model)
+   wrapper = CountWrapper(model)
+
+   mid = X.shape[-1] // 2
+   X_attr = saturation_mutagenesis(
+       wrapper, X,
+       batch_size=512,
+       device="cuda",
+       hypothetical=True,
+       start=mid - 200, end=mid + 200,
+   )
+
+This is what the ``attribute`` CLI subcommand calls internally.
+
+
+Variant effect helpers (Python)
+-------------------------------
+
+For per-variant scoring (not exhaustive ISM), ``tangermeme.variant_effect``
+provides ``substitution_effect``, ``deletion_effect``,
+``insertion_effect``, and ``marginalize`` — each of which wraps the
+ref/alt forward-pair pattern in a helper that handles batching and
+padding. See the tangermeme documentation for signatures.
+
+For ad-hoc substitutions or insertions where you want full control,
+``tangermeme.ersatz`` provides ``substitute``, ``insert``, ``delete``,
+``multisubstitute``, and ``dinucleotide_shuffle`` operations on one-hot
+encoded tensors. The typical pattern is:
+
+.. code-block:: python
+
+   from tangermeme.ersatz import substitute
+   from tangermeme.predict import predict
+
+   X_alt = substitute(X_ref, "<alt sequence>", start=position)
+   y_alt = predict(model, X_alt, batch_size=64, device="cuda")
+
+
+Motif marginalization (CLI)
+---------------------------
+
+To quantify the average causal effect of *inserting* a known motif
+into negative backgrounds, use the ``marginalize`` subcommand. This
+inserts each motif from a MEME file at the center of negative loci
+and reports the predicted change in profile and counts:
+
+.. code-block:: bash
+
+   cherimoya marginalize -p marginalize_params.json
+
+Output goes into a report directory containing per-motif CSVs and an
+HTML summary. The marginalize step is run automatically at the end of
+``cherimoya pipeline`` when a motif database is provided to
+``pipeline-json``.


### PR DESCRIPTION
## Summary

- Comprehensive rewrite of the Sphinx documentation site: organized by audience (bioinformaticians get assay-specific recipes, Python users get tutorials, developers get architecture details + an API reference + a development guide).
- New pages: `benchmarks`, `cli` reference, `glossary`, `troubleshooting`, `development`, four recipes (TF ChIP-seq, ATAC-seq, DNase-seq, conditional analysis), three Python tutorials (`variant_effect`, `save_load`, full training walkthrough), and a `cheri` module API page.
- Existing pages updated to match the current source: corrected default values (Muon `lr=0.025, wd=0.01`; AdamW `lr=0.004, wd=0.2`; cosine `T_max = max_epochs - 5`), dependency list, EMA semantics, and the new inference megakernel dispatch.
- README revised: linked the "What you can do" bullets and CLI examples into the new docs, fixed the ChIP-seq example to use canonical terminology (`-i` is the IP, `-c` is the input control), corrected the "no weight decay" wording, dropped the PRO-seq mention (no recipe exists), and added glossary/troubleshooting pointers at the bottom.
- One source-code fix in `cherimoya/performance.py`: corrected an RST docstring indentation issue in `calculate_performance_measures` that was breaking the warnings-as-errors Sphinx build.

## Test plan

- [ ] `sphinx-build -W -b html docs/ docs/_build` passes with zero warnings (verified locally; only outstanding warnings are from local `.ipynb_checkpoints/` Jupyter cache, gitignored and absent from RTD).
- [ ] Read the Docs build succeeds with `.readthedocs.yml` and `docs/requirements.txt` unchanged.
- [ ] All README link targets resolve (verified locally against the built HTML for all 18 URLs and their in-page anchors).
- [ ] Public API claims in `development.rst` match `cherimoya/__init__.py` (verified: `Cherimoya`, `EMA`, `CheriBlock`).
- [ ] Spot-check the assay recipes render: `recipes/chipseq_tf`, `recipes/atacseq`, `recipes/dnaseq`, `recipes/differential`.
- [ ] Spot-check the new pages render: `glossary`, `troubleshooting`, `development`, `benchmarks`, `cli`, `tutorials/variant_effect`, `tutorials/save_load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)