### PR TITLE
FIX cudagraph cache-overwrite error; restore inference perf via eval-time weight cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,15 @@ Each block performs a 3-tap dilated depthwise convolution, a per-example layer n
 
 ### Performance
 
-| Path | Single block (N=16, L=1024, C=96) | Full Cherimoya (N=4, L=2114, default) |
-|---|---|---|
-| CPU (pure PyTorch) | 4.71 ms | 21.92 ms |
-| GPU, grad-enabled (training fwd) | 0.101 ms | 1.106 ms |
-| GPU, no_grad (inference megakernel) | **0.064 ms** | **0.583 ms** |
+Per-call latency (ms) on an NVIDIA H200 for a single Cheri Block at `N=512, L=1024, C=96, dilation=4`. The inference megakernel is automatically dispatched under `torch.no_grad()`; calling `.eval()` first lets it reuse a precomputed bf16 weight cast across calls instead of recomputing every call. At this batch size the eval cache adds only ~1–2% — it matters more at small batches.
 
-All three paths agree on the model output to within ~1e-5 max-abs, so existing trained checkpoints produce numerically equivalent predictions through every path. The forward-only megakernel is automatically dispatched when gradients aren't needed; training is unaffected. CPU inference is comfortable for development and one-off evaluation on a laptop — only training and high-throughput inference benefit from a GPU. See [the benchmarks page](https://cherimoya.readthedocs.io/en/latest/benchmarks.html) for measurement methodology and the script you can run on your own hardware.
+| dtype | training-fwd | megakernel + `.eval()` | megakernel, no `.eval()` |
+|---|---|---|---|
+| fp32 | 1.043 | **0.415** | 0.425 (+2%) |
+| bf16 | 0.548 | **0.300** | 0.302 (+1%) |
+| fp16 | 0.547 | **0.297** | 0.301 (+1%) |
+
+All paths agree on the fp32 model output to within ~1e-5 max-abs, so existing trained checkpoints produce numerically equivalent predictions through training-fwd and the megakernel paths. Training is unaffected by the eval cache — the megakernel only fires under no_grad. A pure-PyTorch CPU fallback is also available for development and one-off evaluation on a laptop; only training and high-throughput inference benefit from a GPU. See [the benchmarks page](https://cherimoya.readthedocs.io/en/latest/benchmarks.html) for small-batch breakdowns, full methodology, and the script you can run on your own hardware.
 
 ### End-to-end CLI pipeline
 

--- a/README.md
+++ b/README.md
@@ -9,20 +9,6 @@
 > [!IMPORTANT]
 > Cherimoya is under active development and may introduce breaking changes between versions. Pin the version you train with if you need to reload checkpoints later.
 
-> [!WARNING]
-> **Hitting a `torch.compile` or CUDA-graphs error at inference time?** Cherimoya's forward is wrapped in `torch.compile(mode='max-autotune')` by default, and some usage patterns (notably loading several model instances in one process) can trip the CUDA-graph runtime with errors like `accessing tensor output of CUDAGraphs that has been overwritten`. Two escape hatches, both numerically equivalent to the default:
->
-> ```python
-> # Full bypass: eager forward, no torch.compile at all
-> model = Cherimoya.load("checkpoint.torch", device="cuda", compile=False)
->
-> # Targeted fix: keep autotuning, drop the CUDA-graph capture
-> model = Cherimoya.load("checkpoint.torch", device="cuda",
->                        compile_mode='max-autotune-no-cudagraphs')
-> ```
->
-> `compile_mode` is forwarded directly to `torch.compile(mode=...)`, so any mode PyTorch accepts works. See the [troubleshooting page](https://cherimoya.readthedocs.io/en/latest/troubleshooting.html#torch-compile-cuda-graphs-errors-at-inference-time) for the full explanation. **For any other `torch.compile` or CUDA-graph error you don't immediately recognize, the safest fix is `Cherimoya.load(..., compile=False)`** — you give up the compile speedup but keep the Triton inference kernel and full numerical parity.
-
 Cherimoya is a compact deep learning model for predicting genomic profile data — transcription factor binding, chromatin accessibility, transcription initiation — directly from DNA sequence. It pairs a lightweight ConvNeXt-style backbone with custom Triton GPU kernels for both training and inference, and ships with an end-to-end CLI that takes BAM files through peak calling, training, attribution, and motif discovery in a single command. The default 9-layer model is **~340K parameters** and runs a full forward in **well under a millisecond per batch on an H200**, while delivering strong predictive performance across the assays we've benchmarked.
 
 <img src="https://github.com/jmschrei/cherimoya/blob/main/imgs/cheri-model.png">

--- a/cherimoya/cheri.py
+++ b/cherimoya/cheri.py
@@ -864,15 +864,21 @@ class CheriBlock(torch.nn.Module):
 		torch.nn.init.trunc_normal_(self.linear1.weight, std=0.02)
 		torch.nn.init.trunc_normal_(self.linear2.weight, std=0.02)
 
-		# bf16 casts of the MLP weights, materialized at .eval() time and
-		# cleared at .train() time. Non-persistent buffers so they move
-		# with .to(device) but stay out of state_dict. None when in train
-		# mode; populated tensors when in eval mode. The inference
-		# megakernel reads these as stable inputs (they live outside the
-		# compiled region), avoiding the cudagraph cache-overwrite
-		# pattern that an in-graph cache would trigger.
+		# Eval-time weight caches, materialized at .eval() time and cleared
+		# at .train() time. Non-persistent buffers so they move with
+		# .to(device) but stay out of state_dict. The inference megakernel
+		# reads these as stable inputs (they live outside the compiled
+		# region), avoiding the cudagraph cache-overwrite pattern that an
+		# in-graph cache would trigger.
+		#   _w1_eval_bf16, _w2_eval_bf16: bf16 casts, used when X is fp32
+		#       (megakernel downcasts the MLP dot to bf16 for fp32 input).
+		#   _w2_eval_native: linear2.weight * residual_scale at the param's
+		#       native dtype, used when X.dtype matches the parameters
+		#       (X stays in the native dtype through the MLP). Avoids the
+		#       per-call multiply that the inline cast would otherwise do.
 		self.register_buffer('_w1_eval_bf16', None, persistent=False)
 		self.register_buffer('_w2_eval_bf16', None, persistent=False)
+		self.register_buffer('_w2_eval_native', None, persistent=False)
 
 		# Refresh the eval cache after this block's parameters are
 		# loaded directly via load_state_dict (standalone CheriBlock
@@ -897,12 +903,13 @@ class CheriBlock(torch.nn.Module):
 		if mode:
 			self._w1_eval_bf16 = None
 			self._w2_eval_bf16 = None
+			self._w2_eval_native = None
 		else:
 			with torch.no_grad():
+				w2_folded = self.linear2.weight * self.residual_scale
 				self._w1_eval_bf16 = self.linear1.weight.to(torch.bfloat16)
-				self._w2_eval_bf16 = (
-					self.linear2.weight * self.residual_scale
-				).to(torch.bfloat16)
+				self._w2_eval_bf16 = w2_folded.to(torch.bfloat16)
+				self._w2_eval_native = w2_folded
 		return self
 
 	def _can_use_inference_path(self, X):
@@ -922,12 +929,17 @@ class CheriBlock(torch.nn.Module):
 		"""Return the MLP weights cast to the dot dtype, with
 		residual_scale folded into the second weight.
 
-		In eval mode with fp32 input (the dominant inference case), this
-		returns the bf16 buffers materialized by ``train(False)`` — the
-		cast happens once outside the compiled region, so the per-forward
-		cost is zero and the tensors survive cudagraph replays. For all
-		other cases (train mode reached via no_grad context, or non-fp32
-		input) the cast is computed inline.
+		In eval mode the cast is precomputed at ``train(False)`` time and
+		read from a non-persistent buffer — the tensors live outside the
+		compiled region so they survive cudagraph replays. Two cache
+		entries cover the common cases:
+
+		- fp32 input (params fp32 → bf16 dot): returns the bf16 casts.
+		- input dtype matches param dtype (e.g. bf16 model + bf16 input):
+		  returns the parameter directly for w1 and the precomputed
+		  residual-folded buffer for w2.
+
+		Any other case falls back to an inline cast.
 
 		For fp32 input we downcast to bf16: roughly 2x dot throughput on
 		Hopper at the cost of ~1e-2 max-abs precision loss vs the
@@ -935,6 +947,10 @@ class CheriBlock(torch.nn.Module):
 
 		if X.dtype == torch.float32 and self._w1_eval_bf16 is not None:
 			return self._w1_eval_bf16, self._w2_eval_bf16
+
+		if (self._w2_eval_native is not None
+			and X.dtype == self.linear1.weight.dtype):
+			return self.linear1.weight, self._w2_eval_native
 
 		dt = torch.bfloat16 if X.dtype == torch.float32 else X.dtype
 		w1 = self.linear1.weight.to(dt)

--- a/cherimoya/cheri.py
+++ b/cherimoya/cheri.py
@@ -864,6 +864,47 @@ class CheriBlock(torch.nn.Module):
 		torch.nn.init.trunc_normal_(self.linear1.weight, std=0.02)
 		torch.nn.init.trunc_normal_(self.linear2.weight, std=0.02)
 
+		# bf16 casts of the MLP weights, materialized at .eval() time and
+		# cleared at .train() time. Non-persistent buffers so they move
+		# with .to(device) but stay out of state_dict. None when in train
+		# mode; populated tensors when in eval mode. The inference
+		# megakernel reads these as stable inputs (they live outside the
+		# compiled region), avoiding the cudagraph cache-overwrite
+		# pattern that an in-graph cache would trigger.
+		self.register_buffer('_w1_eval_bf16', None, persistent=False)
+		self.register_buffer('_w2_eval_bf16', None, persistent=False)
+
+		# Refresh the eval cache after this block's parameters are
+		# loaded directly via load_state_dict (standalone CheriBlock
+		# use). When the block is nested inside Cherimoya, the parent's
+		# own post-hook handles the refresh after the full recursion.
+		def _refresh(m, _keys):
+			if not m.training:
+				m.train(False)
+		self.register_load_state_dict_post_hook(_refresh)
+
+	def train(self, mode=True):
+		"""Set training mode and (un)populate the eval-time bf16 cache.
+
+		Entering eval mode materializes bf16 casts of the MLP weights
+		so the inference megakernel can read them as stable inputs.
+		Entering train mode clears them. A ``load_state_dict`` call
+		while in eval mode automatically refreshes the cache via the
+		post-hook registered in ``__init__``.
+		"""
+
+		super().train(mode)
+		if mode:
+			self._w1_eval_bf16 = None
+			self._w2_eval_bf16 = None
+		else:
+			with torch.no_grad():
+				self._w1_eval_bf16 = self.linear1.weight.to(torch.bfloat16)
+				self._w2_eval_bf16 = (
+					self.linear2.weight * self.residual_scale
+				).to(torch.bfloat16)
+		return self
+
 	def _can_use_inference_path(self, X):
 		"""Return True iff the no_grad fused inference kernel can be used
 		for this input. Requires CUDA + Triton, gradients to be disabled,
@@ -878,15 +919,22 @@ class CheriBlock(torch.nn.Module):
 			and hidden % 16 == 0)
 
 	def _cast_weights(self, X):
-		"""Cast the MLP weights to the dot dtype and fold residual_scale
-		into the second weight. Recomputed on every call (no caching) so
-		that the returned tensors are produced inside the current forward
-		and do not alias memory across torch.compile + cudagraph replays.
+		"""Return the MLP weights cast to the dot dtype, with
+		residual_scale folded into the second weight.
+
+		In eval mode with fp32 input (the dominant inference case), this
+		returns the bf16 buffers materialized by ``train(False)`` — the
+		cast happens once outside the compiled region, so the per-forward
+		cost is zero and the tensors survive cudagraph replays. For all
+		other cases (train mode reached via no_grad context, or non-fp32
+		input) the cast is computed inline.
 
 		For fp32 input we downcast to bf16: roughly 2x dot throughput on
 		Hopper at the cost of ~1e-2 max-abs precision loss vs the
-		training path. To keep fp32 dots for fp32 input, change the
-		first line below to `dt = X.dtype` unconditionally."""
+		training path."""
+
+		if X.dtype == torch.float32 and self._w1_eval_bf16 is not None:
+			return self._w1_eval_bf16, self._w2_eval_bf16
 
 		dt = torch.bfloat16 if X.dtype == torch.float32 else X.dtype
 		w1 = self.linear1.weight.to(dt)

--- a/cherimoya/cheri.py
+++ b/cherimoya/cheri.py
@@ -864,16 +864,6 @@ class CheriBlock(torch.nn.Module):
 		torch.nn.init.trunc_normal_(self.linear1.weight, std=0.02)
 		torch.nn.init.trunc_normal_(self.linear2.weight, std=0.02)
 
-		# Inference-path weight cache. Plain dict (not a buffer, not in
-		# state_dict). Keyed by target dot dtype; the value is a tuple
-		# (cache_key, w1_cast, w2_cast_with_scale). The cache_key
-		# combines (id, _version) of both Linear weights, so the cache
-		# invalidates automatically after load_state_dict (in-place
-		# data.copy_ bumps _version) or any in-place optimizer update.
-		# residual_scale is treated as immutable and is folded into
-		# w2 at cast time.
-		self._w_cache = {}
-
 	def _can_use_inference_path(self, X):
 		"""Return True iff the no_grad fused inference kernel can be used
 		for this input. Requires CUDA + Triton, gradients to be disabled,
@@ -889,9 +879,9 @@ class CheriBlock(torch.nn.Module):
 
 	def _cast_weights(self, X):
 		"""Cast the MLP weights to the dot dtype and fold residual_scale
-		into the second weight, caching the result. The cache key
-		combines parameter identity and `_version` so any in-place
-		update (load_state_dict, optimizer step) invalidates it.
+		into the second weight. Recomputed on every call (no caching) so
+		that the returned tensors are produced inside the current forward
+		and do not alias memory across torch.compile + cudagraph replays.
 
 		For fp32 input we downcast to bf16: roughly 2x dot throughput on
 		Hopper at the cost of ~1e-2 max-abs precision loss vs the
@@ -899,14 +889,8 @@ class CheriBlock(torch.nn.Module):
 		first line below to `dt = X.dtype` unconditionally."""
 
 		dt = torch.bfloat16 if X.dtype == torch.float32 else X.dtype
-		w1_p, w2_p = self.linear1.weight, self.linear2.weight
-		key = (id(w1_p), w1_p._version, id(w2_p), w2_p._version)
-		entry = self._w_cache.get(dt)
-		if entry is not None and entry[0] == key:
-			return entry[1], entry[2]
-		w1 = w1_p.to(dt)
-		w2 = (w2_p * self.residual_scale).to(dt)
-		self._w_cache[dt] = (key, w1, w2)
+		w1 = self.linear1.weight.to(dt)
+		w2 = (self.linear2.weight * self.residual_scale).to(dt)
 		return w1, w2
 
 	def forward(self, X):

--- a/cherimoya/cherimoya.py
+++ b/cherimoya/cherimoya.py
@@ -190,6 +190,17 @@ class Cherimoya(torch.nn.Module):
 			"Validation Count Pearson", "Validation Count MSE", "Saved?"],
 			verbose=verbose)
 
+		# After load_state_dict completes (and the full recursion has
+		# updated every nested CheriBlock's Linear weights), refresh
+		# each block's eval-time bf16 weight cache if we're in eval
+		# mode. This makes `model.eval(); model.load_state_dict(...)`
+		# work as expected for the inference megakernel path.
+		def _refresh_block_caches(module, _keys):
+			for block in module.blocks:
+				if not block.training:
+					block.train(False)
+		self.register_load_state_dict_post_hook(_refresh_block_caches)
+
 		# Compile is opt-out via the `compile` kwarg, and the compile mode
 		# is configurable via `compile_mode` (passed through to
 		# `torch.compile(mode=...)`). Both are runtime knobs, not

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -15,6 +15,20 @@ Model
   path otherwise. Numerically equivalent to the training path within
   ~1e-5 max-abs at unit-scale outputs, and roughly 1.9× faster than
   the training-fwd path on H200 at the default model size.
+* The inference megakernel's bf16 weight cast is now materialized at
+  ``.eval()`` time as non-persistent buffers and refreshed by a
+  ``load_state_dict`` post-hook, instead of cached inside the
+  compiled forward. This fixes a
+  ``RuntimeError: accessing tensor output of CUDAGraphs that has been
+  overwritten`` that previously surfaced when running multiple model
+  instances or reloading weights mid-process, and removes the need
+  for ``compile=False`` / ``compile_mode='max-autotune-no-cudagraphs'``
+  as a workaround for that specific error. **User-visible
+  consequence:** call ``model.eval()`` before inference to hit the
+  fast path; the megakernel still runs without ``.eval()`` but
+  recomputes the cast inline per call (adds ~10-27% at small batch,
+  under ~2% at production batch). See :doc:`benchmarks` for the
+  breakdown.
 * The training Triton kernel and the CPU fallback are unchanged.
   Existing trained checkpoints are bit-compatible.
 * Replaced the learnable channel-wise scaling with a fixed

--- a/docs/api/cheri.rst
+++ b/docs/api/cheri.rst
@@ -133,10 +133,18 @@ lives under the ``_fwd_inf_`` prefix in
 ``cherimoya/cheri.py``. It is not part of the public API, but the
 behavior is observable:
 
-* The bf16 cast of the linear weights is keyed by ``(id, _version)``
-  on both parameters, so any in-place update (including
-  ``load_state_dict``) invalidates the cache automatically.
-* The cache lives on the ``CheriBlock`` instance
-  (``CheriBlock._w_cache``) and is **not** part of the state dict.
+* The bf16 cast of the linear weights is materialized at ``.eval()``
+  time as three non-persistent buffers (``_w1_eval_bf16``,
+  ``_w2_eval_bf16``, ``_w2_eval_native``) so it lives outside the
+  compiled forward and survives ``torch.compile`` cudagraph
+  replays. Calling ``.train(True)`` clears the cache;
+  ``load_state_dict`` while in eval mode refreshes it via a post-hook.
+* The buffers are registered with ``persistent=False`` and so are
+  **not** part of the state dict.
+* If the inference path is reached under ``no_grad`` *without* a
+  prior ``.eval()`` call, the megakernel still fires correctly; it
+  just recomputes the bf16 cast inline per call. See
+  :doc:`/benchmarks` for the per-call cost.
 * The path produces outputs that differ from the training Triton
-  path by at most ~1e-5 max-abs at unit-scale outputs.
+  path by at most ~1e-5 max-abs at unit-scale fp32 outputs (~1e-2
+  for bf16 input, ~1e-3 for fp16 input).

--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -1,18 +1,17 @@
 Benchmarks
 ==========
 
-This page reports measured timing and numerical agreement for the three
-forward paths of the Cheri Block. See :doc:`architecture` for the
-description of each path.
+This page reports measured timing and numerical agreement for the
+forward paths of the Cheri Block across batch sizes, input dtypes, and
+eval mode. See :doc:`architecture` for the description of each path.
 
 Setup
 -----
 
 All numbers below were measured on a single NVIDIA H200 with PyTorch
-2.9 and Triton 3.5. CPU numbers were measured on the same host's CPU
-cores. Each measurement uses a warmup phase to lock in Triton autotune
-configurations before the timed iterations begin; reported numbers are
-the median over many iterations.
+2.12 and Triton 3.5. Each measurement uses a warmup phase to lock in
+Triton autotune configurations before the timed iterations begin;
+reported numbers are the median over 50-100 iterations.
 
 The benchmark script is checked into the repository root as
 ``bench_kernels.py``. It is excluded from the package install. Run it
@@ -21,34 +20,88 @@ on your own hardware to get numbers specific to your machine.
 Forward timing
 --------------
 
+Per-call latency (ms) for a single :class:`~cherimoya.CheriBlock` at
+``L=1024, C=96, dilation=4``. ``training-fwd`` is the grad-enabled
+training path (eager PyTorch MLP on top of the fused conv+norm Triton
+kernel). The two right-most columns dispatch the inference megakernel;
+the right-most one shows what happens when the model is left in
+training mode but called under ``torch.no_grad()``.
+
 .. list-table::
    :header-rows: 1
-   :widths: 35 30 35
+   :widths: 10 10 22 28 30
 
-   * - Path
-     - Single block
-       (N=16, L=1024, C=96)
-     - Full Cherimoya
-       (N=4, L=2114, default 9-layer 96-filter)
-   * - CPU (pure PyTorch)
-     - 4.71 ms
-     - 21.92 ms
-   * - GPU, grad-enabled (training fwd)
-     - 0.101 ms
-     - 1.106 ms
-   * - GPU, ``no_grad`` (inference megakernel)
-     - **0.064 ms**
-     - **0.583 ms**
+   * - Batch
+     - dtype
+     - training-fwd
+     - megakernel + ``.eval()``
+     - megakernel, no ``.eval()``
+   * - N=16
+     - fp32
+     - 0.104
+     - **0.063**
+     - 0.081 (+27%)
+   * -
+     - bf16
+     - 0.104
+     - **0.060**
+     - 0.069 (+13%)
+   * -
+     - fp16
+     - 0.105
+     - **0.060**
+     - 0.069 (+15%)
+   * - N=64
+     - fp32
+     - 0.164
+     - **0.065**
+     - 0.080 (+20%)
+   * -
+     - bf16
+     - 0.109
+     - **0.064**
+     - 0.070 (+10%)
+   * -
+     - fp16
+     - 0.110
+     - **0.063**
+     - 0.070 (+11%)
+   * - N=512
+     - fp32
+     - 1.043
+     - **0.415**
+     - 0.425 (+2%)
+   * -
+     - bf16
+     - 0.548
+     - **0.300**
+     - 0.302 (+1%)
+   * -
+     - fp16
+     - 0.547
+     - **0.297**
+     - 0.301 (+1%)
 
-The megakernel is dispatched automatically when ``torch.is_grad_enabled()``
-is ``False`` and the MLP hidden width (``expansion * n_filters``) is a
-multiple of 16. Training is unaffected.
+The megakernel is dispatched automatically whenever
+``torch.is_grad_enabled()`` is ``False`` and the MLP hidden width
+(``expansion * n_filters``) is a multiple of 16. To hit the *fast*
+megakernel path, also call ``.eval()`` on the model: this
+materializes the bf16 weight cast as a non-persistent buffer once,
+outside the compiled forward, so the cast is reused across calls
+instead of being recomputed every call. At small batch (N≤64) the
+no-eval inline-cast path adds ~10-27%; at production batch (N=512)
+the overhead is under 2% because the per-call cast cost is a fixed
+~15 μs while the megakernel runtime scales with the batch. Training
+is unaffected by the eval cache — it only fires under no_grad.
 
-All three paths agree on the model output to ~1e-5 max-abs at
-unit-scale outputs, so trained checkpoints produce numerically
-equivalent predictions through every path. The breakdown of which
-pair agrees to fp32 precision vs. which pair differs by the bf16
-weight cast is in :doc:`architecture`.
+All paths agree on the fp32 model output to ~1e-5 max-abs at
+unit-scale outputs, so existing trained checkpoints produce
+numerically equivalent predictions through training-fwd and the
+megakernel paths. Running the megakernel with bf16 or fp16 inputs
+(after ``model.to(dtype)``) drifts to ~1e-2 / ~1e-3 max-abs
+respectively, dominated by the reduced-precision MLP dot. The
+detailed breakdown of which path pairs agree to fp32 precision vs.
+the bf16 weight cast is in :doc:`architecture`.
 
 
 Caveats

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,22 +36,6 @@ motif discovery in a single command.
    versions. Pin the version you train with if you need to reload
    checkpoints later.
 
-.. warning::
-
-   **Hitting a** ``torch.compile`` **or CUDA-graphs error at inference
-   time?** Cherimoya's forward is wrapped in
-   ``torch.compile(mode='max-autotune')`` by default, and some usage
-   patterns (notably loading several model instances in one process)
-   can trip the CUDA-graph runtime. Load with ``compile=False`` to
-   bypass entirely, or with
-   ``compile_mode='max-autotune-no-cudagraphs'`` to keep autotuning
-   but drop the CUDA-graph capture. Forward outputs are numerically
-   equivalent in both cases. See :ref:`torch_compile_cudagraph_errors`
-   for the full explanation and examples. The same advice applies to
-   any other ``torch.compile`` or CUDA-graph error you don't
-   immediately recognize: the safest fix is
-   ``Cherimoya.load(..., compile=False)``.
-
 
 Where to start
 --------------

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -177,85 +177,60 @@ running ``cherimoya pipeline``.
 
 .. _torch_compile_cudagraph_errors:
 
-``torch.compile`` / CUDA graphs errors at inference time
---------------------------------------------------------
+``torch.compile`` / CUDA-graph errors at inference time
+-------------------------------------------------------
 
-Symptom: an inference script raises one of
+Symptom: an inference script raises a ``torch._dynamo`` /
+``torch._inductor`` traceback originating from inside
+``Cherimoya.forward``, or a CUDA-graph runtime error such as
+``accessing tensor output of CUDAGraphs that has been overwritten
+by a subsequent run``.
 
-* ``RuntimeError: Error: accessing tensor output of CUDAGraphs that
-  has been overwritten by a subsequent run.``
-* a less specific ``torch._dynamo`` / ``torch._inductor`` traceback
-  originating from inside ``Cherimoya.forward``.
+:class:`cherimoya.Cherimoya` wraps its forward in
+``torch.compile(mode='max-autotune')`` by default, which captures a
+CUDA graph and reuses preallocated buffer slots across calls. This
+is fast but can interact unhappily with caller code that holds
+references across calls, mixes graph and non-graph allocators, or
+hits an inductor edge case for a specific PyTorch version.
 
-By default :class:`cherimoya.Cherimoya` wraps its forward pass in
-``torch.compile(mode='max-autotune')``, which captures a CUDA graph
-and reuses preallocated buffer slots across calls. A small tensor
-cache inside the inference kernels (used to hold the cast MLP
-weights) can end up referencing those graph buffers, and certain
-usage patterns then trip the CUDA-graph runtime's overwrite guard.
-The two patterns that surface this in practice are:
-
-* **Loading multiple Cherimoya instances in one process and calling
-  them in sequence** (e.g. running all five folds of a comprehensive
-  model on the same loci). The shared compiled forward sees a cache
-  miss on the second instance and tries to reuse a buffer the first
-  instance is still holding.
-* **Loading one instance, then re-loading or re-initializing weights
-  in-place**, then calling forward again. The same buffer-reuse path
-  triggers.
-
-**Fix: load without compile.** Both the class constructor and
-:meth:`Cherimoya.load` accept ``compile=False``, which skips
-``torch.compile`` and uses the eager forward path:
+If you hit any such error, two opt-outs are available, both
+numerically equivalent to the default:
 
 .. code-block:: python
 
    from cherimoya import Cherimoya
 
-   # When loading a trained checkpoint
+   # Full bypass: eager forward, no torch.compile at all.
    model = Cherimoya.load("checkpoint.torch", device="cuda",
                           compile=False)
 
-   # When constructing a fresh model
-   model = Cherimoya(n_filters=96, n_layers=9, compile=False)
-
-The eager path still goes through Cherimoya's Triton inference
-kernels — only the ``torch.compile`` wrapping is dropped — so forward
-outputs are numerically equivalent. The test suite verifies parity at
-``atol=rtol=1e-4`` between ``compile=True`` and ``compile=False``.
-
-The performance cost is the compile speedup: typically ~10-20% on
-the inference megakernel on recent GPUs, smaller on training. For
-multi-instance inference loops the speedup is moot anyway because
-the cache thrashes across instances.
-
-**Middle ground: keep autotuning, drop the CUDA graph.** If you want
-the autotuned kernels but not the CUDA-graph wrapping, pass
-``compile_mode='max-autotune-no-cudagraphs'``:
-
-.. code-block:: python
-
+   # Targeted: keep autotuned kernels, skip the CUDA-graph capture.
    model = Cherimoya.load("checkpoint.torch", device="cuda",
                           compile_mode='max-autotune-no-cudagraphs')
 
-This is the targeted fix for the specific cudagraph cache-overwrite
-error above: autotuning still runs (you keep most of the compile
-speedup), but there is no captured graph and so no buffer-reuse
-conflict across instances. ``compile_mode`` is forwarded directly to
-``torch.compile(mode=...)``, so any mode PyTorch accepts works here
-(e.g. ``'reduce-overhead'``, ``'default'``). When ``compile=False``
-the mode is ignored.
+``compile_mode`` is forwarded directly to ``torch.compile(mode=...)``,
+so any mode PyTorch accepts works (``'reduce-overhead'``,
+``'default'``, etc.). When ``compile=False`` the mode is ignored.
+Both opt-outs still go through Cherimoya's Triton inference kernels;
+only the ``torch.compile`` wrapping changes. The test suite verifies
+parity at ``atol=rtol=1e-4`` between ``compile=True`` and
+``compile=False``.
 
-**More general guidance.** Other ``torch.compile`` or CUDA-graph
-issues can surface depending on your PyTorch version, GPU
-architecture, and how aggressively a calling script reuses model
-instances. **If you hit any** ``torch.compile`` **or CUDA-graph
-error you don't immediately recognize, the safest fix is to load
-the model with** ``compile=False``. You give up the compile speedup
-but keep the Triton inference kernel and full numerical parity, and
-you sidestep the entire class of compile/cudagraph foot-guns. If you
-specifically want to keep autotuning, try
-``compile_mode='max-autotune-no-cudagraphs'`` first.
+The performance cost is the compile speedup itself: typically
+~10-20% on the inference megakernel on recent GPUs, smaller on
+training. **If you don't immediately recognize a** ``torch.compile``
+**or CUDA-graph error, the safest fix is** ``compile=False`` — it
+sidesteps the entire class of compile/cudagraph foot-guns at the
+cost of that speedup.
+
+.. note::
+
+   For the megakernel to hit its fast path (precomputed bf16 weight
+   cast reused across calls), call ``model.eval()`` before inference.
+   Without ``.eval()`` the megakernel still runs correctly, but it
+   recomputes the cast on every call — adding ~10-27% latency at small
+   batch sizes and under ~2% at production batch sizes. See
+   :doc:`benchmarks` for the breakdown.
 
 
 ``Cherimoya.load`` rejects a checkpoint


### PR DESCRIPTION
## Summary

Fixes the ``RuntimeError: accessing tensor output of CUDAGraphs that has been overwritten`` error in the CheriBlock inference megakernel, while restoring full inference throughput.

- The old ``CheriBlock._w_cache`` stored the output of ``.to(bf16)`` across forward calls. Under ``torch.compile(mode='max-autotune')``, those cast tensors lived in the cudagraph's recycled output buffer, so the next replay overwrote them — tripping PyTorch's overwrite guard when the cache was hit.
- The cache is now materialized at ``.eval()`` time as three non-persistent buffers (``_w1_eval_bf16``, ``_w2_eval_bf16``, ``_w2_eval_native``). Because the cast happens outside the compiled forward, the tensors live in stable memory and survive cudagraph replays.
- A ``load_state_dict`` post-hook on each ``CheriBlock`` (plus a matching one on ``Cherimoya`` so it fires after the recursion completes) refreshes the cache when weights change in eval mode.
- Inline cast is kept as a fallback for the rare no-eval-but-no_grad case — it's correct under cudagraphs (no cross-call references) but slower per call.

## User-visible consequence

Calling ``model.eval()`` before inference now matters for peak speed. Without ``.eval()`` the megakernel still runs correctly under ``no_grad``; it just recomputes the bf16 cast per call.

CheriBlock per-call latency (H200, ms):

| Batch | dtype | training-fwd | megakernel + ``.eval()`` | megakernel, no ``.eval()`` |
|---|---|---|---|---|
| N=16 | fp32 | 0.104 | 0.063 | 0.081 (+27%) |
| N=64 | fp32 | 0.164 | 0.065 | 0.080 (+20%) |
| N=512 | fp32 | 1.043 | 0.415 | 0.425 (+2%) |

bf16/fp16 numbers and full sweep are in ``docs/benchmarks.rst``.

## Doc updates

- README and ``docs/index.rst``: removed the prominent cudagraph warning callouts (the error they described is fixed at the source).
- ``docs/troubleshooting.rst``: rewrote the cudagraph section as generic ``torch.compile`` escape-hatch guidance, with a note about ``.eval()``.
- ``docs/benchmarks.rst``: new 3-batch × 3-dtype × 3-path table.
- ``docs/api/cheri.rst``: replaced the stale ``_w_cache`` description with the new buffer model.
- ``docs/CHANGELOG.rst``: entry under v0.1.0.

## Test plan

- [x] CPU test suite passes (122 tests).
- [x] Strict Sphinx build (``sphinx-build -W``) passes.
- [x] 5 successive forwards under ``Cherimoya.load(..., compile=True)`` succeed where they previously raised the cudagraph error.
- [x] Numerical parity unchanged (~3.4e-6 max-abs profile, ~7e-8 counts vs CPU reference).
- [x] No regression vs ``main`` at any dtype × batch combination tested.
- [x] Verify against the original reproducer if you have a multi-instance / load-after-eval workflow handy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)