### PR TITLE
Add GitHub Actions CI for CPU unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  pytest:
+    name: pytest (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install package and test deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install -e .
+          pip install pytest
+
+      - name: Run CPU tests
+        run: pytest -m "not cuda and not triton" -q


### PR DESCRIPTION
## Summary

- New workflow `.github/workflows/test.yml` runs `pytest -m "not cuda and not triton" -q` on `ubuntu-latest` across a Python `3.10` / `3.11` / `3.12` / `3.13` matrix.
- Triggers: every PR targeting `main`, plus every push to `main`.
- Installs the CPU-only torch wheel from `https://download.pytorch.org/whl/cpu` before the editable install, so the runner doesn't pull in the ~3 GB CUDA-bundled torch wheel and its `nvidia-*` transitive deps.
- CUDA/Triton tests auto-skip on the runner via the existing `cuda` / `triton` pytest markers.
- pip cache is enabled via `actions/setup-python@v5` (keyed on `pyproject.toml`), so subsequent runs reuse the wheel cache.

## Test plan

- [ ] First CI run on this PR shows 4 green matrix jobs (3.10–3.13).
- [ ] Install step finishes in roughly a minute on first run, faster on cached runs.
- [ ] Test step reports `205 passed, 22 deselected` (the CPU-only test count from local runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)