### PR TITLE
UPDATE default n_filters and training batch_size to 128

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 > [!IMPORTANT]
 > Cherimoya is under active development and may introduce breaking changes between versions. Pin the version you train with if you need to reload checkpoints later.
 
-Cherimoya is a compact deep learning model for predicting genomic profile data — transcription factor binding, chromatin accessibility, transcription initiation — directly from DNA sequence. It pairs a lightweight ConvNeXt-style backbone with custom Triton GPU kernels for both training and inference, and ships with an end-to-end CLI that takes BAM files through peak calling, training, attribution, and motif discovery in a single command. The default 9-layer model is **~340K parameters** and runs a full forward in **well under a millisecond per batch on an H200**, while delivering strong predictive performance across the assays we've benchmarked.
+Cherimoya is a compact deep learning model for predicting genomic profile data — transcription factor binding, chromatin accessibility, transcription initiation — directly from DNA sequence. It pairs a lightweight ConvNeXt-style backbone with custom Triton GPU kernels for both training and inference, and ships with an end-to-end CLI that takes BAM files through peak calling, training, attribution, and motif discovery in a single command. The default 9-layer model is **~600K parameters** and runs a full forward in **under a millisecond per batch on an H200**, while delivering strong predictive performance across the assays we've benchmarked.
 
 <img src="https://github.com/jmschrei/cherimoya/blob/main/imgs/cheri-model.png">
 
@@ -51,15 +51,15 @@ Each block performs a 3-tap dilated depthwise convolution, a per-example layer n
 
 ### Performance
 
-Per-call latency (ms) on an NVIDIA H200 for a single Cheri Block at `N=512, L=1024, C=96, dilation=4`. The inference megakernel is automatically dispatched under `torch.no_grad()`; calling `.eval()` first lets it reuse a precomputed bf16 weight cast across calls instead of recomputing every call. At this batch size the eval cache adds only ~1–2% — it matters more at small batches.
+Per-call latency (ms) on an NVIDIA H200 for a single Cheri Block at `N=512, L=1024, C=128, dilation=4`, in `.eval()` mode. The inference megakernel is automatically dispatched under `torch.no_grad()`; calling `.eval()` first lets it reuse a precomputed bf16 weight cast across calls instead of recomputing every call, which matters more at small batches (see the benchmarks page).
 
-| dtype | training-fwd | megakernel + `.eval()` | megakernel, no `.eval()` |
-|---|---|---|---|
-| fp32 | 1.043 | **0.415** | 0.425 (+2%) |
-| bf16 | 0.548 | **0.300** | 0.302 (+1%) |
-| fp16 | 0.547 | **0.297** | 0.301 (+1%) |
+| dtype | training-fwd | megakernel |
+|---|---|---|
+| fp32 | 1.340 | **0.499** |
+| bf16 | 0.708 | **0.347** |
+| fp16 | 0.711 | **0.347** |
 
-All paths agree on the fp32 model output to within ~1e-5 max-abs, so existing trained checkpoints produce numerically equivalent predictions through training-fwd and the megakernel paths. Training is unaffected by the eval cache — the megakernel only fires under no_grad. A pure-PyTorch CPU fallback is also available for development and one-off evaluation on a laptop; only training and high-throughput inference benefit from a GPU. See [the benchmarks page](https://cherimoya.readthedocs.io/en/latest/benchmarks.html) for small-batch breakdowns, full methodology, and the script you can run on your own hardware.
+All paths agree on the fp32 model output to within ~1e-5 max-abs, so existing trained checkpoints produce numerically equivalent predictions through training-fwd and the megakernel paths. Training is unaffected by the eval cache — the megakernel only fires under no_grad. A pure-PyTorch CPU fallback is also available for development and one-off evaluation on a laptop; only training and high-throughput inference benefit from a GPU. See [the benchmarks page](https://cherimoya.readthedocs.io/en/latest/benchmarks.html) for small-batch breakdowns and full methodology.
 
 ### End-to-end CLI pipeline
 
@@ -106,7 +106,7 @@ For programmatic use, the three public symbols are `Cherimoya` (the model), `Che
 ```python
 from cherimoya import Cherimoya
 
-model = Cherimoya(n_filters=96, n_layers=9).cuda()
+model = Cherimoya(n_filters=128, n_layers=9).cuda()
 y_profile, y_counts = model(X)              # X: (N, 4, L) one-hot DNA
 ```
 

--- a/cherimoya/cherimoya.py
+++ b/cherimoya/cherimoya.py
@@ -101,7 +101,7 @@ class Cherimoya(torch.nn.Module):
 	----------
 	n_filters: int, optional
 		Width of the convolutional backbone (the channel dimension).
-		Default is 96.
+		Default is 128.
 
 	n_layers: int, optional
 		Number of stacked Cheri Blocks. Block ``i`` uses dilation
@@ -145,7 +145,7 @@ class Cherimoya(torch.nn.Module):
 		is True.
 	"""
 
-	def __init__(self, n_filters=96, n_layers=9, signal_groups=None,
+	def __init__(self, n_filters=128, n_layers=9, signal_groups=None,
 		n_control_tracks=0, expansion=2, residual_scale=0.15, name=None,
 		trimming=None, verbose=True, compile=True,
 		compile_mode='max-autotune'):
@@ -395,7 +395,7 @@ class Cherimoya(torch.nn.Module):
 
 	def fit(self, training_data, muon_optimizer, adam_optimizer, lw_optimizer,
 		muon_scheduler, adam_scheduler, lw_scheduler, X_valid, X_ctl_valid,
-		y_valid, max_epochs=50, batch_size=64, dtype='float32', device='cuda',
+		y_valid, max_epochs=50, batch_size=128, dtype='float32', device='cuda',
 		early_stopping=None):
 		"""Fit the model to data and validate it periodically.
 
@@ -461,7 +461,7 @@ class Cherimoya(torch.nn.Module):
 			number of times that `training_data` is exhausted. Default is 50.
 
 		batch_size: int, optional
-			The number of examples to include in each batch. Default is 64.
+			The number of examples to include in each batch. Default is 128.
 
 		dtype: str or torch.dtype
 			The torch.dtype to use when training. Usually, this will be torch.float32

--- a/cherimoya_cli/defaults.py
+++ b/cherimoya_cli/defaults.py
@@ -32,12 +32,12 @@ validation_chroms = ['chr8', 'chr20']
 
 
 default_fit_parameters = {
-	'n_filters': 96,
+	'n_filters': 128,
 	'n_layers': 9,
 	'expansion': 2,
 	'residual_scale': 0.15,
 	'name': None,
-	'batch_size': 64,
+	'batch_size': 128,
 	'in_window': 2114,
 	'out_window': 1000,
 	'max_jitter': 50,
@@ -208,11 +208,11 @@ default_pipeline_parameters = {
 
 	# Fit parameters
 	'fit_parameters': {
-		'n_filters': 96,
+		'n_filters': 128,
 		'n_layers': 9,
 		'expansion': 2,
 		'residual_scale': 0.15,
-		'batch_size': 64,
+		'batch_size': 128,
 		'muon_lr': 0.025,
 		'muon_wd': 0.03,
 		'adam_lr': 0.001,

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -114,6 +114,18 @@ Model (**breaking**)
   Pearson are computed, so a stranded pair contributes a single
   per-group target instead of one per strand.
 
+Training defaults
+~~~~~~~~~~~~~~~~~
+
+* The default backbone width ``n_filters`` is now 128 (was 96), so the
+  default 9-layer model has roughly 600K parameters (was ~340K). This
+  applies to the ``Cherimoya`` constructor and the ``fit_parameters``
+  defaults used by ``cherimoya fit`` / ``cherimoya pipeline``.
+* The default training ``batch_size`` is now 128 (was 64), in both the
+  ``Cherimoya.fit`` method and the CLI ``fit_parameters`` defaults. Both
+  the 128-filter, 128-batch defaults still fit comfortably on a 16 GB
+  GPU; reduce ``batch_size`` to 64 if you run out of GPU memory.
+
 v0.1.0
 ------
 

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -25,7 +25,7 @@ The model consists of three stages.
 1. **Input stem**. A 1D convolution (``kernel_size=21``, padding 10)
    maps the one-hot encoded DNA sequence (4 channels) into
    ``n_filters`` channels, followed by a GELU non-linearity. Default
-   ``n_filters`` is 96.
+   ``n_filters`` is 128.
 
 2. **Cheri-block backbone**. A stack of ``n_layers`` (default 9) Cheri
    Blocks with exponentially increasing dilation rates ``1, 2, 4, …,
@@ -40,7 +40,7 @@ The model consists of three stages.
    *group* (``len(signal_groups)`` total). A stranded ``(+, -)`` pair is
    one group, so its two strands share a single count target.
 
-The default 9-layer, 96-filter model has roughly 340K parameters. The
+The default 9-layer, 128-filter model has roughly 600K parameters. The
 default input window is 2114 bp and the default output window is 1000
 bp; the difference (557 bp on each side) is the ``trimming`` and equals
 ``46 + sum(2**i for i in range(n_layers))`` by default. The ``46`` is

--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -13,15 +13,15 @@ All numbers below were measured on a single NVIDIA H200 with PyTorch
 Triton autotune configurations before the timed iterations begin;
 reported numbers are the median over 50-100 iterations.
 
-The benchmark script is checked into the repository root as
-``bench_kernels.py``. It is excluded from the package install. Run it
-on your own hardware to get numbers specific to your machine.
+These numbers were produced by ``bench_kernels.py``, a local
+development script that lives in the repository root but is not tracked
+in git or shipped with the package.
 
 Forward timing
 --------------
 
 Per-call latency (ms) for a single :class:`~cherimoya.CheriBlock` at
-``L=1024, C=96, dilation=4``. ``training-fwd`` is the grad-enabled
+``L=1024, C=128, dilation=4``. ``training-fwd`` is the grad-enabled
 training path (eager PyTorch MLP on top of the fused conv+norm Triton
 kernel). The two right-most columns dispatch the inference megakernel;
 the right-most one shows what happens when the model is left in
@@ -38,49 +38,49 @@ training mode but called under ``torch.no_grad()``.
      - megakernel, no ``.eval()``
    * - N=16
      - fp32
-     - 0.104
-     - **0.063**
-     - 0.081 (+27%)
+     - 0.101
+     - **0.062**
+     - 0.079 (+27%)
    * -
      - bf16
-     - 0.104
-     - **0.060**
-     - 0.069 (+13%)
+     - 0.101
+     - **0.061**
+     - 0.067 (+10%)
    * -
      - fp16
-     - 0.105
+     - 0.102
      - **0.060**
-     - 0.069 (+15%)
+     - 0.066 (+9%)
    * - N=64
      - fp32
-     - 0.164
-     - **0.065**
-     - 0.080 (+20%)
+     - 0.198
+     - **0.075**
+     - 0.083 (+11%)
    * -
      - bf16
      - 0.109
-     - **0.064**
-     - 0.070 (+10%)
+     - **0.060**
+     - 0.066 (+10%)
    * -
      - fp16
-     - 0.110
-     - **0.063**
-     - 0.070 (+11%)
+     - 0.109
+     - **0.060**
+     - 0.065 (+9%)
    * - N=512
      - fp32
-     - 1.043
-     - **0.415**
-     - 0.425 (+2%)
+     - 1.340
+     - **0.499**
+     - 0.509 (+2%)
    * -
      - bf16
-     - 0.548
-     - **0.300**
-     - 0.302 (+1%)
+     - 0.708
+     - **0.347**
+     - 0.348 (+1%)
    * -
      - fp16
-     - 0.547
-     - **0.297**
-     - 0.301 (+1%)
+     - 0.711
+     - **0.347**
+     - 0.356 (+3%)
 
 The megakernel is dispatched automatically whenever
 ``torch.is_grad_enabled()`` is ``False`` and the MLP hidden width
@@ -89,8 +89,8 @@ megakernel path, also call ``.eval()`` on the model: this
 materializes the bf16 weight cast as a non-persistent buffer once,
 outside the compiled forward, so the cast is reused across calls
 instead of being recomputed every call. At small batch (N≤64) the
-no-eval inline-cast path adds ~10-27%; at production batch (N=512)
-the overhead is under 2% because the per-call cast cost is a fixed
+no-eval inline-cast path adds ~9-27%; at production batch (N=512)
+the overhead is ~1-3% because the per-call cast cost is a fixed
 ~15 μs while the megakernel runtime scales with the batch. Training
 is unaffected by the eval cache — it only fires under no_grad.
 
@@ -98,7 +98,7 @@ All paths agree on the fp32 model output to ~1e-5 max-abs at
 unit-scale outputs, so existing trained checkpoints produce
 numerically equivalent predictions through training-fwd and the
 megakernel paths. Running the megakernel with bf16 or fp16 inputs
-(after ``model.to(dtype)``) drifts to ~1e-2 / ~1e-3 max-abs
+(after ``model.to(dtype)``) drifts to ~3e-2 / ~4e-3 max-abs
 respectively, dominated by the reduced-precision MLP dot. The
 detailed breakdown of which path pairs agree to fp32 precision vs.
 the bf16 weight cast is in :doc:`architecture`.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -260,7 +260,7 @@ Unspecified keys fall back to the fit-level defaults.
      - Default
      - Description
    * - ``n_filters``
-     - 96
+     - 128
      - Backbone channel width.
    * - ``n_layers``
      - 9

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,7 +67,7 @@ Design highlights
 
 * **Cheri Blocks**. A dilated depthwise convolution fused with a
   per-example layer normalization and a channel-mixing MLP, implemented
-  as a custom Triton kernel. The default 9-layer model is ~340K
+  as a custom Triton kernel. The default 9-layer model is ~600K
   parameters with a 1115 bp receptive field.
 * **Three forward paths, one set of weights**. A CPU fallback, a
   Triton fwd+bwd kernel for training, and a fwd-only megakernel for

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -130,10 +130,10 @@ Verifying the installation
    print(cherimoya.__version__)
 
    from cherimoya import Cherimoya
-   model = Cherimoya(n_filters=96, n_layers=9)
+   model = Cherimoya(n_filters=128, n_layers=9)
    print("Parameters:", sum(p.numel() for p in model.parameters()))
 
-The default 9-layer model has roughly 340K parameters. The package will
+The default 9-layer model has roughly 600K parameters. The package will
 import and the model will instantiate without a GPU; a CUDA device is
 only needed when you call ``.cuda()`` or pass tensors that live on a
 GPU.
@@ -142,15 +142,15 @@ GPU.
 Hardware expectations
 ---------------------
 
-The default 9-layer, 96-filter Cherimoya model is small (~340K
+The default 9-layer, 128-filter Cherimoya model is small (~600K
 parameters). The dominant memory cost during training is the
 activations and the optimizer state, not the parameters; both scale
 linearly with ``batch_size``, ``in_window``, and ``n_filters``.
 
 In practice:
 
-* The default training configuration (``batch_size=64``,
-  ``in_window=2114``, ``n_filters=96``, 9 layers) fits comfortably on
+* The default training configuration (``batch_size=128``,
+  ``in_window=2114``, ``n_filters=128``, 9 layers) fits comfortably on
   a 16 GB GPU.
 * Inference at ``batch_size=512`` (the CLI default) fits on the same
   hardware.
@@ -177,7 +177,7 @@ that the output shapes are right:
    import torch
    from cherimoya import Cherimoya
 
-   model = Cherimoya(n_filters=96, n_layers=9)
+   model = Cherimoya(n_filters=128, n_layers=9)
    if torch.cuda.is_available():
        model = model.cuda()
 

--- a/docs/multi_task.rst
+++ b/docs/multi_task.rst
@@ -117,7 +117,7 @@ Python:
 
    from cherimoya import Cherimoya
 
-   model = Cherimoya(n_filters=96, n_layers=9).cuda()
+   model = Cherimoya(n_filters=128, n_layers=9).cuda()
 
    X = ...                                       # (N, 4, 2114) one-hot DNA
    y_profile, y_counts = model(X)
@@ -199,7 +199,7 @@ Python:
    from cherimoya import Cherimoya
 
    model = Cherimoya(
-       n_filters=96, n_layers=9,
+       n_filters=128, n_layers=9,
        signal_groups=[2],            # one stranded (+, -) pair
        n_control_tracks=2,           # stranded input control
    ).cuda()
@@ -300,7 +300,7 @@ Python:
    # (2 channels): three groups, five profile channels, three count
    # predictions.
    model = Cherimoya(
-       n_filters=96, n_layers=9,
+       n_filters=128, n_layers=9,
        signal_groups=[1, 2, 2],
        n_control_tracks=0,
    ).cuda()

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -38,7 +38,7 @@ Python API
    import torch
    from cherimoya import Cherimoya
 
-   model = Cherimoya(n_filters=96, n_layers=9).cuda()
+   model = Cherimoya(n_filters=128, n_layers=9).cuda()
    X = torch.randn(2, 4, 2114, device="cuda")
    with torch.no_grad():
        y_profile, y_counts = model(X)
@@ -53,7 +53,7 @@ group of two channels that share a count prediction — pass
 
 .. code-block:: python
 
-   model = Cherimoya(n_filters=96, n_layers=9, signal_groups=[2]).cuda()
+   model = Cherimoya(n_filters=128, n_layers=9, signal_groups=[2]).cuda()
    with torch.no_grad():
        y_profile, y_counts = model(X)
 

--- a/docs/recipes/chipseq_tf.rst
+++ b/docs/recipes/chipseq_tf.rst
@@ -61,7 +61,7 @@ Steps invoked, in order:
    (``ctcf.+.bw``, ``ctcf.-.bw``, ``ctcf.control.+.bw``,
    ``ctcf.control.-.bw``).
 3. GC-matched negative sampling (``ctcf.negatives.bed``).
-4. Train a 9-layer 96-filter Cherimoya model with
+4. Train a 9-layer 128-filter Cherimoya model with
    ``signal_groups=[2]`` (one stranded ``(+, -)`` group) and
    ``n_control_tracks=2``.
 5. Compute count attributions via saturation mutagenesis on the
@@ -87,8 +87,8 @@ If you want to deviate from defaults, edit the JSON before running
      - Default
      - When to change
    * - ``fit_parameters.n_filters``
-     - 96
-     - Smaller (64) for faster experiments; larger (128) for very
+     - 128
+     - Smaller (64) for faster experiments; larger (192) for very
        complex assays.
    * - ``fit_parameters.n_layers``
      - 9

--- a/docs/recipes/dnaseq.rst
+++ b/docs/recipes/dnaseq.rst
@@ -62,7 +62,7 @@ Steps invoked, in order:
 2. ``bam2bw`` converts the BAM to an unstranded bigWig
    (``dnase_experiment.bw``).
 3. GC-matched negative sampling (``dnase_experiment.negatives.bed``).
-4. Train a 9-layer 96-filter Cherimoya model with
+4. Train a 9-layer 128-filter Cherimoya model with
    ``signal_groups=[1]`` and ``n_control_tracks=0``.
 5. Compute count attributions via saturation mutagenesis on the
    validation chromosomes.

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -21,7 +21,7 @@ peaks. As a rough guide:
   carefully.
 * 10,000+ peaks → default configuration is appropriate.
 * 50,000+ peaks → no special handling needed; larger models
-  (``n_filters=128``) become worth trying.
+  (``n_filters=192`` or ``256``) become worth trying.
 
 **Library depth.** Cherimoya needs enough reads per peak that the
 profile MNLL is informative. As a rough guide:
@@ -44,13 +44,13 @@ CUDA out of memory at the start of training
 Symptom: ``torch.cuda.OutOfMemoryError`` in the first or second
 training step.
 
-The default training batch size (64) and input window (2114 bp) fit
-comfortably on a 16 GB GPU at the default 9-layer, 96-filter model.
+The default training batch size (128) and input window (2114 bp) fit
+comfortably on a 16 GB GPU at the default 9-layer, 128-filter model.
 If you hit OOM, the fastest fixes:
 
-* Reduce ``fit_parameters.batch_size`` from 64 to 32 or 16.
+* Reduce ``fit_parameters.batch_size`` from 128 to 64 (or 32).
 * Use bf16 autocast: set ``fit_parameters.dtype`` to ``"bfloat16"``.
-* Shrink the model: ``fit_parameters.n_filters`` from 96 to 64 or 48.
+* Shrink the model: ``fit_parameters.n_filters`` from 128 to 64 or 48.
 
 GPU memory at training time is dominated by activations
 (``batch_size × in_window × n_filters × n_layers`` plus the

--- a/docs/tutorials/python_api.rst
+++ b/docs/tutorials/python_api.rst
@@ -16,7 +16,7 @@ Creating a model
    from cherimoya import Cherimoya
 
    model = Cherimoya(
-       n_filters=96,              # backbone width
+       n_filters=128,             # backbone width
        n_layers=9,                # number of Cheri Blocks (dilations 1, 2, ..., 256)
        signal_groups=[2],         # one stranded (+, -) group; see below
        n_control_tracks=0,        # number of control input tracks
@@ -96,7 +96,7 @@ a ``torch.utils.data.DataLoader``:
        max_jitter=50,                       # peak-center jitter at training time
        negative_ratio=0.02,                 # n_negatives per n_peaks per epoch
        reverse_complement=True,             # augment with reverse complements
-       batch_size=64,
+       batch_size=128,
        num_workers=1,                       # async prefetch workers
        random_state=0,                      # base seed; reproducible
        verbose=True,                        # print progress and filter counts
@@ -219,7 +219,7 @@ Training
        X_ctl_valid=None,            # pass control tensors here if using controls
        y_valid=y_valid,
        max_epochs=20,
-       batch_size=64,
+       batch_size=128,
        early_stopping=5,            # stop after 5 epochs without count-Pearson gain
        dtype='float32',             # or 'bfloat16' for mixed precision via autocast
        device='cuda',

--- a/docs/tutorials/save_load.rst
+++ b/docs/tutorials/save_load.rst
@@ -14,7 +14,7 @@ Saving
 
    from cherimoya import Cherimoya
 
-   model = Cherimoya(n_filters=96, n_layers=9)
+   model = Cherimoya(n_filters=128, n_layers=9)
    # ... train ...
    model.save("my_model.torch")
 

--- a/tests/test_cheri.py
+++ b/tests/test_cheri.py
@@ -404,14 +404,14 @@ def test_cheri_block_no_grad_matches_grad_cuda(dtype, atol):
 
 @pytest.mark.cuda
 @pytest.mark.triton
-def test_cheri_block_no_grad_matches_grad_cuda_n_filters_96():
-	"""Production models default to n_filters=96 (hidden=192). Verify the
+def test_cheri_block_no_grad_matches_grad_cuda_n_filters_128():
+	"""Production models default to n_filters=128 (hidden=256). Verify the
 	inference path holds parity at the actual deployment width, since
 	autotuned kernels behave differently across shapes."""
 
 	torch.manual_seed(0)
-	block = CheriBlock(n_filters=96, dilation=4).cuda()
-	x = torch.randn(2, 256, 96, device='cuda')
+	block = CheriBlock(n_filters=128, dilation=4).cuda()
+	x = torch.randn(2, 256, 128, device='cuda')
 
 	y_grad = block(x)
 	with torch.no_grad():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -25,7 +25,7 @@ def _input_window_for(model):
 
 def test_default_construction():
 	model = Cherimoya(verbose=False)
-	assert model.n_filters == 96
+	assert model.n_filters == 128
 	assert model.n_layers == 9
 	assert model.n_outputs == 1
 	assert model.n_control_tracks == 0


### PR DESCRIPTION
## Summary
- Bump default `n_filters` **96 → 128** and default training `batch_size` **64 → 128** across the Python API (`Cherimoya` constructor, `fit`) and CLI defaults (`default_fit_parameters` + pipeline `fit_parameters`). The default 9-layer model is now **~600K params** (was ~340K).
- Sweep all docs to match (README, architecture, cli, index, installation, quickstart, multi_task, troubleshooting, recipes, tutorials), recompute the param count everywhere, and add a **Training defaults** CHANGELOG entry.
- Update default-value assertions in tests; rename the CUDA deployment-width parity test to `n_filters=128` (hidden=256).
- Refresh benchmark tables with new H200 numbers measured at **C=128**. The README table is collapsed to a single **megakernel** column (the no-`.eval()` path is within noise at N=512); the benchmarks page keeps the full three-column table + eval-cache discussion, where the columns still diverge at small batch.
- Correct both pages to stop claiming `bench_kernels.py` is checked in — it's a local, gitignored dev script.

## Verification
- `pytest -m "not cuda and not triton"` → **205 passed**
- `cd docs && sphinx-build -W -b html . _build/html` → **build succeeded** (strict)
- Benchmark numbers re-run on an idle H200 NVL (`CUDA_VISIBLE_DEVICES=7`) after discarding contended runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)