### PR TITLE
ADD cherimoya.wrappers and reduce bpnet-lite wrapper dependency

### DIFF
--- a/cherimoya/__init__.py
+++ b/cherimoya/__init__.py
@@ -4,5 +4,9 @@
 from .cherimoya import Cherimoya
 from .cherimoya import EMA
 from .cheri import CheriBlock
+from .wrappers import ControlWrapper
+from .wrappers import ProfileWrapper
+from .wrappers import LogCountWrapper
+from .wrappers import ExpectedCountsWrapper
 
 __version__ = '0.1.0'

--- a/cherimoya/wrappers.py
+++ b/cherimoya/wrappers.py
@@ -1,0 +1,166 @@
+# wrappers.py
+# Author: Jacob Schreiber <jmschreiber91@gmail.com>
+
+"""
+A set of wrappers to help in using Cherimoya models.
+"""
+
+import torch
+
+
+class ControlWrapper(torch.nn.Module):
+	"""A wrapper that supplies an all-zero control track when none is given.
+
+	Cherimoya models trained with control tracks expect a control tensor at
+	every forward pass, but attribution and marginalization tools call the model
+	with the sequence alone. This wrapper bridges that gap: when no control is
+	passed it checks whether the model expects one and, if so, synthesizes a
+	control track of all zeroes with the matching shape, dtype, and device. Models
+	without control tracks are forwarded through unchanged. The wrapper returns the
+	model's full ``(profile, log-count)`` output, so it is meant to be the inner
+	wrapper that :class:`ProfileWrapper`, :class:`LogCountWrapper`, or
+	:class:`ExpectedCountsWrapper` are layered on top of. This is a port of
+	``bpnetlite.bpnet.ControlWrapper`` so that Cherimoya does not depend on
+	bpnet-lite for this behavior.
+
+
+	Parameters
+	----------
+	model: cherimoya.Cherimoya
+		A Cherimoya model, which makes predictions for basepair resolution profiles
+		and also for log counts.
+	"""
+
+	def __init__(self, model):
+		super().__init__()
+		self.model = model
+
+	def forward(self, X, X_ctl=None):
+		if X_ctl is not None:
+			return self.model(X, X_ctl)
+
+		if self.model.n_control_tracks == 0:
+			return self.model(X)
+
+		X_ctl = torch.zeros(X.shape[0], self.model.n_control_tracks,
+			X.shape[-1], dtype=X.dtype, device=X.device)
+		return self.model(X, X_ctl)
+
+
+class _ProfileLogitScaling(torch.nn.Module):
+	"""A non-linear scaling of profile logits, isolated for Captum.
+
+	This module performs the non-linear part of :class:`ProfileWrapper` —
+	multiplying logits by their own softmax — in its own ``forward`` so that
+	Captum can register it as a non-linear operation. Captum classifies each
+	registered module as linear or non-linear; the wrapper's inputs are the
+	one-hot sequence (run through the model) rather than the logits being
+	modified, so the non-linear logit operations must be quarantined here
+	for attribution methods that walk the module graph.
+	"""
+
+	def __init__(self):
+		super().__init__()
+		self.softmax = torch.nn.Softmax(dim=-1)
+
+	def forward(self, logits):
+		y_softmax = self.softmax(logits)
+		return logits * y_softmax
+
+
+class ProfileWrapper(torch.nn.Module):
+	"""A wrapper that returns the weighted-softmax of the profile logits.
+
+	This wrapper takes the predicted profile logits and returns the dot product
+	between them and their softmaxed values, summed across positions. The
+	mean-centering and softmax weighting collapse the per-position profile into
+	a single number per example whose attribution reflects the predicted profile
+	*shape*. This is a port of ``bpnetlite.bpnet.ProfileWrapper`` so that
+	Cherimoya does not depend on bpnet-lite for attribution.
+
+
+	Parameters
+	----------
+	model: cherimoya.Cherimoya
+		A Cherimoya model, which makes predictions for basepair resolution profiles
+		and also for log counts.
+	"""
+
+	def __init__(self, model):
+		super().__init__()
+		self.model = model
+		self.flatten = torch.nn.Flatten()
+		self.scaling = _ProfileLogitScaling()
+
+	def forward(self, X, X_ctl=None):
+		logits = self.model(X, X_ctl=X_ctl)[0]
+		logits = self.flatten(logits)
+		logits = logits - torch.mean(logits, dim=-1, keepdims=True)
+		return self.scaling(logits).sum(dim=-1, keepdims=True)
+
+
+class LogCountWrapper(torch.nn.Module):
+	"""A wrapper that extracts the log count predictions.
+
+	This wraps a Cherimoya and slices out the second prediction, which is for the
+	log counts. This is useful when you only care about the log count predictions,
+	such as for feature attribution or design methods.
+
+
+	Parameters
+	----------
+	model: cherimoya.Cherimoya
+		A Cherimoya model, which makes predictions for basepair resolution profiles
+		and also for log counts.
+	"""
+
+	def __init__(self, model):
+		super().__init__()
+		self.model = model
+
+	def forward(self, X, X_ctl=None):
+		return self.model(X, X_ctl=X_ctl)[1]
+
+
+class ExpectedCountsWrapper(torch.nn.Module):
+	"""A wrapper that provides the expected counts per basepair.
+
+	This wrapper combines the profile predictions and the log count predictions to
+	give the expected number of reads mapping to each position. This is done by
+	exponentiating the log count predictions and multiplying them by the softmaxed
+	logit profiles. Essentially, we are distributing counts (not log counts) by the
+	predicted probability distribution across positions.
+
+	The distribution is performed jointly within each signal group. A group's
+	profile channels and positions are softmaxed together so that the probabilities
+	sum to one across the *entire* group, and the group's counts are then spread
+	across all of its channels and positions. For a stranded ``(+, -)`` pair this
+	means the expected counts summed over both strands and all positions equals the
+	predicted count for that group. The count head is trained against
+	``log(count + 1)``, so :func:`torch.expm1` is used to recover the counts.
+
+
+	Parameters
+	----------
+	model: cherimoya.Cherimoya
+		A Cherimoya model, which makes predictions for basepair resolution profiles
+		and also for log counts.
+	"""
+
+	def __init__(self, model):
+		super().__init__()
+		self.model = model
+
+	def forward(self, X, X_ctl=None):
+		y_logits, y_logcounts = self.model(X, X_ctl=X_ctl)
+		y_counts = torch.expm1(y_logcounts)
+
+		y_expected = []
+		y_logit_groups = torch.split(y_logits, self.model.signal_groups, dim=1)
+		for i, logits in enumerate(y_logit_groups):
+			batch_size, n_channels, length = logits.shape
+			probs = torch.softmax(logits.reshape(batch_size, -1), dim=-1)
+			probs = probs.reshape(batch_size, n_channels, length)
+			y_expected.append(probs * y_counts[:, i, None, None])
+
+		return torch.cat(y_expected, dim=1)

--- a/cherimoya_cli/commands/attribute.py
+++ b/cherimoya_cli/commands/attribute.py
@@ -16,13 +16,13 @@ def run(args):
 	import numpy
 	import torch
 
-	from bpnetlite.bpnet import ControlWrapper
-	from bpnetlite.bpnet import CountWrapper
-	from bpnetlite.bpnet import ProfileWrapper
 	from tangermeme.io import extract_loci
 	from tangermeme.saturation_mutagenesis import saturation_mutagenesis
 
 	from cherimoya import Cherimoya
+	from cherimoya import ControlWrapper
+	from cherimoya import LogCountWrapper
+	from cherimoya import ProfileWrapper
 	from ..defaults import default_attribute_parameters
 	from ..utils import merge_parameters
 
@@ -51,7 +51,7 @@ def run(args):
 
 	model = ControlWrapper(model)
 	if parameters['output'] == 'counts':
-		wrapper = CountWrapper(model)
+		wrapper = LogCountWrapper(model)
 	elif parameters['output'] == 'profile':
 		wrapper = ProfileWrapper(model)
 	else:

--- a/cherimoya_cli/commands/evaluate.py
+++ b/cherimoya_cli/commands/evaluate.py
@@ -15,11 +15,11 @@ def run(args):
 
 	import torch
 
-	from bpnetlite.bpnet import ControlWrapper
 	from tangermeme.io import extract_loci
 	from tangermeme.predict import predict
 
 	from cherimoya import Cherimoya
+	from cherimoya import ControlWrapper
 	from cherimoya.io import normalize_signal_groups
 	from cherimoya.performance import calculate_performance_measures
 	from ..defaults import default_evaluate_parameters

--- a/cherimoya_cli/commands/marginalize.py
+++ b/cherimoya_cli/commands/marginalize.py
@@ -16,11 +16,11 @@ def run(args):
 	import numpy
 	import torch
 
-	from bpnetlite.bpnet import ControlWrapper
 	from bpnetlite.marginalize import marginalization_report
 	from tangermeme.io import extract_loci
 
 	from cherimoya import Cherimoya
+	from cherimoya import ControlWrapper
 	from ..defaults import default_marginalize_parameters
 	from ..utils import merge_parameters
 

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -178,6 +178,19 @@ API
 * :class:`cherimoya.cherimoya.EMA` is now a public top-level symbol
   alongside :class:`cherimoya.Cherimoya` and
   :class:`cherimoya.CheriBlock`.
+* Added a :mod:`cherimoya.wrappers` module exposing four public
+  wrappers: :class:`cherimoya.ControlWrapper`,
+  :class:`cherimoya.ProfileWrapper`, :class:`cherimoya.LogCountWrapper`,
+  and :class:`cherimoya.ExpectedCountsWrapper`. ``ControlWrapper`` and
+  ``ProfileWrapper`` are drop-in ports of the bpnet-lite wrappers;
+  ``LogCountWrapper`` returns the per-group log-counts; and
+  ``ExpectedCountsWrapper`` distributes each group's counts (``expm1``
+  of the log-count) across its channels and positions via a joint
+  softmax, so the expected counts summed over a group equal its
+  predicted count. ``cherimoya attribute`` and ``cherimoya marginalize``
+  now use these in place of ``bpnetlite``'s ``ControlWrapper``,
+  ``CountWrapper``, and ``ProfileWrapper``, so the subcommands no longer
+  import any wrappers from bpnet-lite.
 
 Training
 ~~~~~~~~

--- a/docs/api/wrappers.rst
+++ b/docs/api/wrappers.rst
@@ -1,0 +1,92 @@
+cherimoya.wrappers
+==================
+
+.. module:: cherimoya.wrappers
+
+Thin :class:`torch.nn.Module` wrappers around a :class:`~cherimoya.Cherimoya`
+that expose a single tensor from its ``(profile, log-count)`` output, so the
+model can be dropped straight into attribution and design tools that expect a
+one-tensor forward pass, plus :class:`ControlWrapper`, which supplies a
+zero control track to models that expect one. All four are re-exported from
+the top-level ``cherimoya`` namespace.
+
+
+ControlWrapper
+--------------
+
+.. autoclass:: ControlWrapper
+   :members: forward
+   :undoc-members:
+   :show-inheritance:
+
+   .. rubric:: Constructor
+
+   .. automethod:: __init__
+
+Returns the model's full ``(profile, log-count)`` output, synthesizing an
+all-zero control track when the model expects one but none is passed. It is
+the inner wrapper that the output wrappers below are layered on top of — for
+example ``LogCountWrapper(ControlWrapper(model))`` — and is what
+``cherimoya attribute`` and ``cherimoya marginalize`` use so a model can be
+called with the sequence alone. A drop-in port of
+``bpnetlite.bpnet.ControlWrapper``.
+
+
+ProfileWrapper
+--------------
+
+.. autoclass:: ProfileWrapper
+   :members: forward
+   :undoc-members:
+   :show-inheritance:
+
+   .. rubric:: Constructor
+
+   .. automethod:: __init__
+
+Returns the mean-centered profile logits weighted by their own softmax and
+summed across positions, collapsing the predicted profile into a single
+shape-sensitive number per example. This is the wrapper used by
+``cherimoya attribute`` when ``output`` is ``"profile"`` (see
+:doc:`../tutorials/attribution`). It is a drop-in port of
+``bpnetlite.bpnet.ProfileWrapper`` so that attribution does not require
+bpnet-lite. As with :class:`LogCountWrapper`, pair it with
+:class:`ControlWrapper` for models trained with control tracks.
+
+
+LogCountWrapper
+---------------
+
+.. autoclass:: LogCountWrapper
+   :members: forward
+   :undoc-members:
+   :show-inheritance:
+
+   .. rubric:: Constructor
+
+   .. automethod:: __init__
+
+Returns the model's per-group log-count predictions. This is the wrapper
+used by ``cherimoya attribute`` when ``output`` is ``"counts"`` (see
+:doc:`../tutorials/attribution`). Pair it with :class:`ControlWrapper` when
+attributing a model that was trained with control tracks, so that zero
+controls are supplied automatically.
+
+
+ExpectedCountsWrapper
+---------------------
+
+.. autoclass:: ExpectedCountsWrapper
+   :members: forward
+   :undoc-members:
+   :show-inheritance:
+
+   .. rubric:: Constructor
+
+   .. automethod:: __init__
+
+Combines the profile and log-count heads into the expected number of reads
+at each position. Within each signal group the profile channels and
+positions are softmaxed jointly and scaled by ``expm1`` of that group's
+log-count, so the expected counts summed over the whole group (e.g. both
+strands of a stranded pair) equal the predicted count for the group.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -135,6 +135,7 @@ measured numbers.
 
    api/model
    api/cheri
+   api/wrappers
    api/io
    api/losses
    api/performance

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -85,9 +85,9 @@ are taken from ``pyproject.toml``.
      - Sequence loading, attribution (saturation mutagenesis), and
        seqlet extraction primitives.
    * - ``bpnet-lite`` (≥ 1.0.0)
-     - Multinomial NLL and log1p-MSE losses; ControlWrapper /
-       CountWrapper / ProfileWrapper helpers used by the attribute and
-       marginalize subcommands.
+     - The multinomial NLL profile loss (``MNLLLoss``) and training
+       ``Logger`` used during fitting, and ``marginalization_report``
+       used by the marginalize subcommand.
    * - ``macs3``
      - Peak calling, invoked by the ``pipeline`` subcommand.
    * - ``bam2bw`` (≥ 0.4.1)

--- a/docs/tutorials/attribution.rst
+++ b/docs/tutorials/attribution.rst
@@ -51,15 +51,15 @@ Example JSON:
 ``output`` controls what is being attributed to:
 
 * ``"counts"`` — attribute to total predicted log-counts (recommended
-  for most analyses).
+  for most analyses; uses :class:`cherimoya.LogCountWrapper`).
 * ``"profile"`` — attribute to the predicted profile shape (uses
-  ``ProfileWrapper`` from ``bpnetlite``).
+  :class:`cherimoya.ProfileWrapper`).
 
 The CLI automatically:
 
 1. Loads sequences from ``loci`` on ``chroms`` and filters out any
    example containing an ``N`` over the input window.
-2. Wraps the model with ``bpnetlite.bpnet.ControlWrapper`` (passing
+2. Wraps the model with :class:`cherimoya.ControlWrapper` (passing
    zero controls if the model has none) and then with the chosen
    output wrapper.
 3. Runs ``tangermeme.saturation_mutagenesis.saturation_mutagenesis``
@@ -81,7 +81,9 @@ Computing attributions (Python)
 
    import torch
    from cherimoya import Cherimoya
-   from bpnetlite.bpnet import ControlWrapper, CountWrapper
+   from cherimoya import ControlWrapper
+   from cherimoya import LogCountWrapper
+   from cherimoya import ProfileWrapper
    from tangermeme.saturation_mutagenesis import saturation_mutagenesis
 
    model = Cherimoya.load("my_model.torch", device="cuda")
@@ -89,7 +91,7 @@ Computing attributions (Python)
    # ControlWrapper wraps the model so that .forward(X) returns just the
    # profile/counts tuple, supplying zero controls if the model has none.
    model = ControlWrapper(model)
-   wrapper = CountWrapper(model)   # use ProfileWrapper(...) to attribute to profile shape
+   wrapper = LogCountWrapper(model)   # use ProfileWrapper(...) to attribute to profile shape
 
    # ISM over the central 400 bp of each input sequence.
    mid = X.shape[-1] // 2

--- a/docs/tutorials/variant_effect.rst
+++ b/docs/tutorials/variant_effect.rst
@@ -79,13 +79,15 @@ For an in-silico saturation mutagenesis sweep over a region, use
 
    import torch
    from cherimoya import Cherimoya
+   from cherimoya import ControlWrapper
+   from cherimoya import LogCountWrapper
    from tangermeme.saturation_mutagenesis import saturation_mutagenesis
-   from bpnetlite.bpnet import ControlWrapper, CountWrapper
 
    model = Cherimoya.load("my_model.torch", device="cuda")
-   if model.n_control_tracks > 0:
-       model = ControlWrapper(model)
-   wrapper = CountWrapper(model)
+   # ControlWrapper passes control-free models straight through, so it is
+   # safe to apply unconditionally.
+   model = ControlWrapper(model)
+   wrapper = LogCountWrapper(model)
 
    mid = X.shape[-1] // 2
    X_attr = saturation_mutagenesis(

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -48,7 +48,7 @@ def test_residual_scale_round_trips_through_save_load(tmp_path):
 		verbose=False)
 	path = tmp_path / "m.torch"
 	model.save(str(path))
-	loaded = Cherimoya.load(str(path))
+	loaded = Cherimoya.load(str(path), compile=False)
 	assert loaded.residual_scale == 0.42
 	for block in loaded.blocks:
 		assert block.residual_scale == 0.42
@@ -66,7 +66,7 @@ def test_expansion_round_trips_through_save_load(tmp_path):
 	model = Cherimoya(n_filters=8, n_layers=2, expansion=4, verbose=False)
 	path = tmp_path / "m.torch"
 	model.save(str(path))
-	loaded = Cherimoya.load(str(path))
+	loaded = Cherimoya.load(str(path), compile=False)
 	assert loaded.expansion == 4
 	for block in loaded.blocks:
 		assert block.linear1.out_features == 32
@@ -412,7 +412,7 @@ def test_save_load_roundtrip_preserves_predictions(tmp_path, small_model_kwargs)
 	path = tmp_path / "model.torch"
 	model.save(str(path))
 
-	loaded = Cherimoya.load(str(path)).eval()
+	loaded = Cherimoya.load(str(path), compile=False).eval()
 	assert loaded.n_filters == model.n_filters
 	assert loaded.n_layers == model.n_layers
 	got_profile, got_counts = loaded(X)
@@ -435,7 +435,7 @@ def test_load_to_specified_device(tmp_path, small_model_kwargs, device):
 	model = Cherimoya(**small_model_kwargs)
 	path = tmp_path / "model.torch"
 	model.save(str(path))
-	loaded = Cherimoya.load(str(path), device=device)
+	loaded = Cherimoya.load(str(path), device=device, compile=False)
 	# Check at least one parameter ended up on the requested device.
 	param = next(loaded.parameters())
 	assert param.device.type == device
@@ -485,7 +485,7 @@ def test_model_save_load_predictions_match_under_no_grad(tmp_path,
 
 	path = tmp_path / "model.torch"
 	model.save(str(path))
-	loaded = Cherimoya.load(str(path)).eval()
+	loaded = Cherimoya.load(str(path), compile=False).eval()
 
 	with torch.no_grad():
 		got_profile, got_counts = loaded(X)
@@ -576,7 +576,7 @@ def test_model_save_load_no_grad_matches_grad_cuda(tmp_path):
 
 	path = tmp_path / "model.torch"
 	model.save(str(path))
-	loaded = Cherimoya.load(str(path), device='cuda').eval()
+	loaded = Cherimoya.load(str(path), device='cuda', compile=False).eval()
 
 	with torch.no_grad():
 		got_profile, got_counts = loaded(X)

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1,0 +1,416 @@
+"""Tests for the model wrappers in ``cherimoya.wrappers``."""
+
+import pytest
+import torch
+
+from numpy.testing import assert_array_almost_equal
+
+from cherimoya import Cherimoya
+from cherimoya.wrappers import ControlWrapper
+from cherimoya.wrappers import ProfileWrapper
+from cherimoya.wrappers import LogCountWrapper
+from cherimoya.wrappers import ExpectedCountsWrapper
+
+
+def _input_window_for(model):
+	"""Compute a valid input window length for `model`."""
+	# Output window must be > 0; trimming bytes are removed from each side.
+	return 2 * model.trimming + 64
+
+
+@pytest.fixture
+def grouped_model():
+	# One unstranded track plus one stranded (+, -) pair: the profile head
+	# emits sum([1, 2]) = 3 channels while the count head emits len([1, 2]) = 2
+	# predictions. This is the config that exercises the channel-vs-group
+	# bookkeeping in ExpectedCountsWrapper. Seed first so the random weight
+	# init is fixed and the regression values below are reproducible.
+	torch.manual_seed(0)
+	return Cherimoya(n_filters=8, n_layers=2, signal_groups=[1, 2],
+		verbose=False, compile=False).eval()
+
+
+@pytest.fixture
+def control_model():
+	torch.manual_seed(0)
+	return Cherimoya(n_filters=8, n_layers=2, signal_groups=[1, 2],
+		n_control_tracks=1, verbose=False, compile=False).eval()
+
+
+# --------- ControlWrapper --------------------------------------------------
+
+def test_control_wrapper_passthrough_no_controls(grouped_model):
+	"""A model with no control tracks is forwarded through unchanged."""
+	L = _input_window_for(grouped_model)
+	torch.manual_seed(0)
+	X = torch.randn(4, 4, L)
+
+	with torch.no_grad():
+		ref_profile, ref_counts = grouped_model(X)
+		profile, counts = ControlWrapper(grouped_model)(X)
+
+	assert torch.equal(profile, ref_profile)
+	assert torch.equal(counts, ref_counts)
+
+
+def test_control_wrapper_synthesizes_zero_control(control_model):
+	"""When the model expects a control track but none is passed, an all-zero
+	track of the right shape is supplied — equivalent to passing zeros."""
+	L = _input_window_for(control_model)
+	torch.manual_seed(0)
+	X = torch.randn(2, 4, L)
+	X_ctl = torch.zeros(2, control_model.n_control_tracks, L)
+
+	with torch.no_grad():
+		ref_profile, ref_counts = control_model(X, X_ctl=X_ctl)
+		profile, counts = ControlWrapper(control_model)(X)
+
+	assert torch.equal(profile, ref_profile)
+	assert torch.equal(counts, ref_counts)
+
+
+def test_control_wrapper_forwards_given_control(control_model):
+	"""An explicit control track is passed straight through to the model."""
+	L = _input_window_for(control_model)
+	torch.manual_seed(0)
+	X = torch.randn(2, 4, L)
+	X_ctl = torch.rand(2, 1, L)
+
+	with torch.no_grad():
+		ref_profile, ref_counts = control_model(X, X_ctl=X_ctl)
+		profile, counts = ControlWrapper(control_model)(X, X_ctl=X_ctl)
+
+	assert torch.equal(profile, ref_profile)
+	assert torch.equal(counts, ref_counts)
+
+
+def test_control_wrapper_matches_bpnetlite(control_model):
+	"""The port is numerically identical to bpnet-lite's ControlWrapper."""
+	bpnet = pytest.importorskip("bpnetlite.bpnet")
+
+	L = _input_window_for(control_model)
+	torch.manual_seed(0)
+	X = torch.randn(2, 4, L)
+
+	with torch.no_grad():
+		ours_profile, ours_counts = ControlWrapper(control_model)(X)
+		theirs_profile, theirs_counts = bpnet.ControlWrapper(control_model)(X)
+
+	assert_array_almost_equal(ours_profile.numpy(), theirs_profile.numpy(), 6)
+	assert_array_almost_equal(ours_counts.numpy(), theirs_counts.numpy(), 6)
+
+
+def test_control_wrapper_composes_with_output_wrappers(control_model):
+	"""The CLI pattern: an output wrapper layered on ControlWrapper runs a
+	control-track model from the sequence alone."""
+	L = _input_window_for(control_model)
+	torch.manual_seed(0)
+	X = torch.randn(2, 4, L)
+
+	wrapped = ControlWrapper(control_model)
+	with torch.no_grad():
+		counts = LogCountWrapper(wrapped)(X)
+		profile = ProfileWrapper(wrapped)(X)
+
+	assert counts.shape == (2, 2)
+	assert profile.shape == (2, 1)
+
+
+# --------- ProfileWrapper --------------------------------------------------
+
+def test_profile_wrapper_shape(grouped_model):
+	"""The wrapper collapses the profile to one number per example."""
+	L = _input_window_for(grouped_model)
+	torch.manual_seed(0)
+	X = torch.randn(4, 4, L)
+
+	with torch.no_grad():
+		y_hat = ProfileWrapper(grouped_model)(X)
+
+	assert y_hat.shape == (4, 1)
+
+
+def test_profile_wrapper_matches_bpnetlite(grouped_model):
+	"""The port is numerically identical to bpnet-lite's ProfileWrapper."""
+	bpnet = pytest.importorskip("bpnetlite.bpnet")
+
+	L = _input_window_for(grouped_model)
+	torch.manual_seed(0)
+	X = torch.randn(2, 4, L)
+
+	with torch.no_grad():
+		ours = ProfileWrapper(grouped_model)(X)
+		theirs = bpnet.ProfileWrapper(grouped_model)(X)
+
+	assert_array_almost_equal(ours.numpy(), theirs.numpy(), 6)
+
+
+def test_profile_wrapper_regression(grouped_model):
+	"""Regression on the profile attribution target for a fixed seed."""
+	L = _input_window_for(grouped_model)
+	torch.manual_seed(1)
+	X = torch.randn(2, 4, L)
+
+	with torch.no_grad():
+		y_hat = ProfileWrapper(grouped_model)(X)
+
+	assert_array_almost_equal(y_hat.numpy(), [
+		[0.00002024],
+		[0.00002500]], 6)
+
+
+def test_profile_wrapper_passes_control(control_model):
+	"""The control track is forwarded through to the model."""
+	L = _input_window_for(control_model)
+	torch.manual_seed(0)
+	X = torch.randn(3, 4, L)
+	X_ctl = torch.rand(3, 1, L)
+
+	with torch.no_grad():
+		expected = ProfileWrapper(control_model)(X, X_ctl=X_ctl)
+
+	assert expected.shape == (3, 1)
+	assert torch.isfinite(expected).all()
+
+
+def test_profile_wrapper_is_differentiable(grouped_model):
+	"""Gradients flow to the input — the attribution use case."""
+	L = _input_window_for(grouped_model)
+	torch.manual_seed(0)
+	X = torch.randn(2, 4, L, requires_grad=True)
+
+	ProfileWrapper(grouped_model)(X).sum().backward()
+
+	assert X.grad is not None
+	assert torch.isfinite(X.grad).all()
+
+
+# --------- LogCountWrapper -------------------------------------------------
+
+def test_logcount_wrapper_matches_count_head(grouped_model):
+	"""The wrapper output is exactly the model's second return value."""
+	L = _input_window_for(grouped_model)
+	torch.manual_seed(0)
+	X = torch.randn(4, 4, L)
+
+	with torch.no_grad():
+		_, y_logcounts = grouped_model(X)
+		y_hat = LogCountWrapper(grouped_model)(X)
+
+	assert y_hat.shape == (4, 2)
+	assert torch.equal(y_hat, y_logcounts)
+
+
+def test_logcount_wrapper_regression(grouped_model):
+	"""Regression on the log-count values for a fixed seed."""
+	L = _input_window_for(grouped_model)
+	torch.manual_seed(1)
+	X = torch.randn(2, 4, L)
+
+	with torch.no_grad():
+		y_hat = LogCountWrapper(grouped_model)(X)
+
+	assert_array_almost_equal(y_hat.numpy(), [
+		[-0.00007713, 0.00112576],
+		[-0.00055159, 0.00089704]], 6)
+
+
+def test_logcount_wrapper_passes_control(control_model):
+	"""The control track is forwarded through to the model."""
+	L = _input_window_for(control_model)
+	torch.manual_seed(0)
+	X = torch.randn(3, 4, L)
+	# Control tracks are read counts; the count head takes log(sum + 1), so
+	# they must be non-negative.
+	X_ctl = torch.rand(3, 1, L)
+
+	with torch.no_grad():
+		expected = control_model(X, X_ctl=X_ctl)[1]
+		y_hat = LogCountWrapper(control_model)(X, X_ctl=X_ctl)
+
+	assert torch.equal(y_hat, expected)
+
+
+def test_logcount_wrapper_is_differentiable(grouped_model):
+	"""Gradients flow to the input — the attribution use case."""
+	L = _input_window_for(grouped_model)
+	torch.manual_seed(0)
+	X = torch.randn(2, 4, L, requires_grad=True)
+
+	LogCountWrapper(grouped_model)(X).sum().backward()
+
+	assert X.grad is not None
+	assert torch.isfinite(X.grad).all()
+
+
+# --------- ExpectedCountsWrapper -------------------------------------------
+
+def test_expected_counts_shape_matches_profile(grouped_model):
+	"""Output has the profile head's shape: (batch, sum(groups), out_len)."""
+	L = _input_window_for(grouped_model)
+	out_L = L - 2 * grouped_model.trimming
+	torch.manual_seed(0)
+	X = torch.randn(4, 4, L)
+
+	with torch.no_grad():
+		y_hat = ExpectedCountsWrapper(grouped_model)(X)
+
+	assert y_hat.shape == (4, 3, out_L)
+
+
+def test_expected_counts_group_sum_equals_counts(grouped_model):
+	"""Summing expected counts over a group's channels and positions
+	recovers expm1(log_count) for that group — including both strands of
+	the stranded pair."""
+	L = _input_window_for(grouped_model)
+	torch.manual_seed(0)
+	X = torch.randn(4, 4, L)
+
+	with torch.no_grad():
+		y_logits, y_logcounts = grouped_model(X)
+		y_hat = ExpectedCountsWrapper(grouped_model)(X)
+
+	expected_total = torch.expm1(y_logcounts)
+	# Group 0 is the unstranded channel; group 1 is the stranded pair.
+	group0 = y_hat[:, 0:1].sum(dim=(1, 2))
+	group1 = y_hat[:, 1:3].sum(dim=(1, 2))
+
+	assert_array_almost_equal(group0.numpy(), expected_total[:, 0].numpy(), 4)
+	assert_array_almost_equal(group1.numpy(), expected_total[:, 1].numpy(), 4)
+
+
+def test_expected_counts_softmax_is_joint_over_group(grouped_model):
+	"""Within a group the distribution is joint: dividing the expected
+	counts by the group's counts yields probabilities that sum to one across
+	the group's channels and positions, not per-channel."""
+	L = _input_window_for(grouped_model)
+	torch.manual_seed(2)
+	X = torch.randn(3, 4, L)
+
+	with torch.no_grad():
+		_, y_logcounts = grouped_model(X)
+		y_hat = ExpectedCountsWrapper(grouped_model)(X)
+
+	counts = torch.expm1(y_logcounts)
+	probs1 = y_hat[:, 1:3] / counts[:, 1, None, None]
+	# Joint over the pair: total mass is one. Per-channel it would be two.
+	assert_array_almost_equal(probs1.sum(dim=(1, 2)).numpy(),
+		torch.ones(3).numpy(), 4)
+
+
+def test_expected_counts_single_unstranded_group():
+	"""The default single-group config reduces to a plain softmax-times-count
+	distribution over positions."""
+	torch.manual_seed(0)
+	model = Cherimoya(n_filters=8, n_layers=2, signal_groups=[1],
+		verbose=False, compile=False).eval()
+	L = _input_window_for(model)
+	torch.manual_seed(0)
+	X = torch.randn(2, 4, L)
+
+	with torch.no_grad():
+		y_logits, y_logcounts = model(X)
+		y_hat = ExpectedCountsWrapper(model)(X)
+
+	reference = torch.softmax(y_logits, dim=-1) * torch.expm1(y_logcounts)[:, :, None]
+	assert_array_almost_equal(y_hat.numpy(), reference.numpy(), 4)
+
+
+def test_expected_counts_regression(grouped_model):
+	"""Regression on the expected counts at a few positions for a fixed
+	seed."""
+	L = _input_window_for(grouped_model)
+	torch.manual_seed(1)
+	X = torch.randn(2, 4, L)
+
+	with torch.no_grad():
+		y_hat = ExpectedCountsWrapper(grouped_model)(X)
+
+	# First three positions of each channel for the first example.
+	assert_array_almost_equal(y_hat[0, :, :3].numpy(), [
+		[-0.00000121, -0.00000119, -0.00000120],
+		[0.00000880, 0.00000881, 0.00000885],
+		[0.00000880, 0.00000882, 0.00000878]], 6)
+
+
+def test_expected_counts_passes_control(control_model):
+	"""The control track is forwarded through to the model."""
+	L = _input_window_for(control_model)
+	torch.manual_seed(0)
+	X = torch.randn(3, 4, L)
+	X_ctl = torch.rand(3, 1, L)
+
+	with torch.no_grad():
+		y_logits, y_logcounts = control_model(X, X_ctl=X_ctl)
+		y_hat = ExpectedCountsWrapper(control_model)(X, X_ctl=X_ctl)
+
+	expected_total = torch.expm1(y_logcounts)
+	group1 = y_hat[:, 1:3].sum(dim=(1, 2))
+	assert_array_almost_equal(group1.numpy(), expected_total[:, 1].numpy(), 4)
+
+
+def test_expected_counts_is_differentiable(grouped_model):
+	"""Gradients flow to the input."""
+	L = _input_window_for(grouped_model)
+	torch.manual_seed(0)
+	X = torch.randn(2, 4, L, requires_grad=True)
+
+	ExpectedCountsWrapper(grouped_model)(X).sum().backward()
+
+	assert X.grad is not None
+	assert torch.isfinite(X.grad).all()
+
+
+# --------- Error handling --------------------------------------------------
+
+def test_profile_wrapper_rejects_wrong_channel_count(grouped_model):
+	"""A sequence that is not 4-channel one-hot fails in the input conv."""
+	L = _input_window_for(grouped_model)
+	X = torch.randn(2, 5, L)
+
+	with pytest.raises(RuntimeError):
+		ProfileWrapper(grouped_model)(X)
+
+
+def test_logcount_wrapper_rejects_wrong_channel_count(grouped_model):
+	"""A sequence that is not 4-channel one-hot fails in the input conv."""
+	L = _input_window_for(grouped_model)
+	X = torch.randn(2, 5, L)
+
+	with pytest.raises(RuntimeError):
+		LogCountWrapper(grouped_model)(X)
+
+
+def test_expected_counts_rejects_wrong_channel_count(grouped_model):
+	"""A sequence that is not 4-channel one-hot fails in the input conv."""
+	L = _input_window_for(grouped_model)
+	X = torch.randn(2, 5, L)
+
+	with pytest.raises(RuntimeError):
+		ExpectedCountsWrapper(grouped_model)(X)
+
+
+def test_expected_counts_requires_signal_groups_attribute(grouped_model):
+	"""ExpectedCountsWrapper reads ``model.signal_groups`` to split the
+	profile head; wrapping a model without it raises AttributeError. This
+	pins the contract that it wraps a Cherimoya directly, not another
+	wrapper."""
+	L = _input_window_for(grouped_model)
+	X = torch.randn(2, 4, L)
+
+	# Wrapping the LogCountWrapper (which has no signal_groups and returns
+	# only counts) is a misuse and should surface clearly.
+	wrapped = ExpectedCountsWrapper(LogCountWrapper(grouped_model))
+
+	with pytest.raises(AttributeError):
+		wrapped(X)
+
+
+def test_expected_counts_missing_control_raises(control_model):
+	"""A model built with control tracks needs the control tensor; omitting
+	it fails in the profile conv where the channels no longer line up."""
+	L = _input_window_for(control_model)
+	X = torch.randn(2, 4, L)
+
+	with pytest.raises(RuntimeError):
+		ExpectedCountsWrapper(control_model)(X)


### PR DESCRIPTION
## Summary

Adds a new `cherimoya.wrappers` module exposing four public wrappers and migrates the CLI off bpnet-lite's wrappers entirely.

- **`ControlWrapper`** — port of `bpnetlite.bpnet.ControlWrapper`; synthesizes an all-zero control track for models that expect one, passes control-free models through unchanged. Returns the full `(profile, log-count)` tuple.
- **`ProfileWrapper`** — port of `bpnetlite.bpnet.ProfileWrapper`; mean-centered profile logits weighted by their own softmax, summed across positions.
- **`LogCountWrapper`** — returns the model's per-group log-count predictions.
- **`ExpectedCountsWrapper`** — expected reads per position: within each signal group the profile channels and positions are softmaxed jointly and scaled by `expm1` of the group's log-count, so the expected counts summed over the whole group (e.g. both strands of a stranded pair) equal the predicted count.

All four are re-exported from the top-level `cherimoya` namespace.

## CLI migration

`attribute`, `evaluate`, and `marginalize` now use the cherimoya wrappers. **No production code imports any wrapper from bpnet-lite anymore** — the remaining bpnet-lite usage is non-wrapper utilities only (`MNLLLoss`, `Logger`, `marginalization_report`).

## Tests

- New `tests/test_wrappers.py` (26 tests), including numerical-equivalence checks of the `ControlWrapper`/`ProfileWrapper` ports against bpnet-lite (skipped if bpnet-lite is absent), the group-sum invariant for `ExpectedCountsWrapper`, control-track handling, differentiability, and error cases.
- Pass `compile=False` to every `Cherimoya.load` in the suite except `test_compile.py` (which tests the compile default), avoiding pointless compilation warm-up.
- Full suite: **253 passed**.

## Docs

New `docs/api/wrappers.rst` (wired into the API toctree); updated attribution and variant-effect tutorials, installation dependency table, and CHANGELOG. Strict Sphinx build (`-W`) passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)