### PR TITLE
Release v0.1.1

### DIFF
--- a/cherimoya/__init__.py
+++ b/cherimoya/__init__.py
@@ -9,4 +9,4 @@ from .wrappers import ProfileWrapper
 from .wrappers import LogCountWrapper
 from .wrappers import ExpectedCountsWrapper
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-Unreleased
-----------
+v0.1.1
+------
 
 Data pipeline (**breaking**)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@ sys.path.insert(0, os.path.abspath('..'))
 project = 'Cherimoya'
 copyright = '2026, Jacob Schreiber'
 author = 'Jacob Schreiber'
-release = '0.1.0'
+release = '0.1.1'
 
 # -- General configuration ---------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cherimoya"
-version = "0.1.0"
+version = "0.1.1"
 description = "A light-weight deep learning architecture that uses modern optimization tricks to achieve strong predictive performance."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump **0.1.0 → 0.1.1** and promotion of the `Unreleased` changelog section to `v0.1.1`.

## Version refs bumped
- `cherimoya/__init__.py` — `__version__`
- `pyproject.toml` — `version`
- `docs/conf.py` — `release`
- `docs/CHANGELOG.rst` — `Unreleased` → `v0.1.1`

No code changes — the actual functional changes already landed via #17 and earlier PRs and are summarized in the `v0.1.1` changelog section.

## Release contents (from the changelog)
- **Data pipeline (breaking):** fixed RC scrambling for mixed unstranded/stranded signals; grouped `signals`/`controls` form (flat list = N unstranded groups).
- **Model (breaking):** `signal_groups` replaces `n_outputs`; removed `single_count_output`; profile head `fconv` is now a 75-bp conv (`kernel_size=75, padding=37`); pre-grouping / 1×1-head checkpoints no longer load.
- **Training defaults:** `negative_ratio` 0.02→0.25, `batch_size` 128→192, `max_jitter` 50→500; default model ~610K params.

## Verification
- Strict Sphinx build (`sphinx-build -W`) passes.
- `import cherimoya; cherimoya.__version__` → `0.1.1`.

After merge, the remaining release steps (tag `v0.1.1` on main, publish) are manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)