### PR TITLE
REWRITE CLI entry point to defer command imports for faster --help

### DIFF
--- a/cherimoya/__init__.py
+++ b/cherimoya/__init__.py
@@ -8,5 +8,3 @@ from .wrappers import ControlWrapper
 from .wrappers import ProfileWrapper
 from .wrappers import LogCountWrapper
 from .wrappers import ExpectedCountsWrapper
-
-__version__ = '0.1.1'

--- a/cherimoya_cli/__main__.py
+++ b/cherimoya_cli/__main__.py
@@ -2,61 +2,298 @@
 # Author: Jacob Schreiber <jmschreiber91@gmail.com>
 
 import argparse
-
-from cherimoya import __version__
-
-from .commands import negatives
-from .commands import pipeline_json
-from .commands import fit
-from .commands import evaluate
-from .commands import attribute
-from .commands import seqlets
-from .commands import marginalize
-from .commands import pipeline
-from .commands import batch
-from .commands import install_skill
-
+import importlib
+from importlib.metadata import version, PackageNotFoundError
 
 desc = """A command-line tool for the training and usage of Cherimoya models."""
 
 _help = """Must be either 'negatives', 'fit', 'evaluate',
-	'attribute', 'seqlets', 'marginalize', 'pipeline', or 'install-skill'."""
+    'attribute', 'seqlets', 'marginalize', 'pipeline', or 'install-skill'."""
+
+try:
+    __version__ = version("cherimoya")
+except PackageNotFoundError:
+    __version__ = "0.0.0+unknown"
+
+
+def _setup_parsers() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=desc)
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="cherimoya {}".format(__version__),
+    )
+    subparsers = parser.add_subparsers(help=_help, required=True, dest="cmd")
+
+    # Negatives
+    negatives_parser = subparsers.add_parser(
+        "negatives", help="Sample GC-matched negatives."
+    )
+    negatives_parser.add_argument("-i", "--peaks", required=True, help="Peak bed file.")
+    negatives_parser.add_argument("-f", "--fasta", help="Genome FASTA file.")
+    negatives_parser.add_argument("-b", "--bigwig", help="Optional signal bigwig.")
+    negatives_parser.add_argument(
+        "-o", "--output", required=True, help="Output bed file."
+    )
+    negatives_parser.add_argument(
+        "-l", "--bin_width", type=float, default=0.02, help="GC bin width to match."
+    )
+    negatives_parser.add_argument(
+        "-n",
+        "--max_n_perc",
+        type=float,
+        default=0.1,
+        help="Maximum percentage of Ns allowed in each locus.",
+    )
+    negatives_parser.add_argument(
+        "-a",
+        "--beta",
+        type=float,
+        default=0.5,
+        help="Multiplier on the minimum counts in peaks.",
+    )
+    negatives_parser.add_argument(
+        "-w",
+        "--in_window",
+        type=int,
+        default=2114,
+        help="Width for calculating GC content.",
+    )
+    negatives_parser.add_argument(
+        "-x",
+        "--out_window",
+        type=int,
+        default=1000,
+        help="Non-overlapping stride to use for loci.",
+    )
+    negatives_parser.add_argument("-v", "--verbose", default=False, action="store_true")
+
+    # Pipeline JSON
+    pipeline_json_parser = subparsers.add_parser(
+        "pipeline-json",
+        help="Make a pipeline JSON file given the provided information.",
+    )
+    pipeline_json_parser.add_argument(
+        "-s", "--sequences", type=str, help="The FASTA file of sequences."
+    )
+    pipeline_json_parser.add_argument(
+        "-i",
+        "--inputs",
+        type=str,
+        action="append",
+        help="A BAM or bigwig file. Repeatable.",
+    )
+    pipeline_json_parser.add_argument(
+        "-c",
+        "--controls",
+        type=str,
+        action="append",
+        help="A BAM or bigwig file. Repeatable.",
+    )
+    pipeline_json_parser.add_argument(
+        "-p",
+        "--peaks",
+        type=str,
+        action="append",
+        help="A BED-formatted file of peaks to use. Repeatable.",
+    )
+    pipeline_json_parser.add_argument(
+        "-neg",
+        "--negatives",
+        type=str,
+        action="append",
+        help="A BED-formatted file of negative loci to use. Repeatable.",
+    )
+    pipeline_json_parser.add_argument(
+        "-n", "--name", type=str, help="Name to use as a suffix in intermediary files."
+    )
+    pipeline_json_parser.add_argument(
+        "-u",
+        "--unstranded",
+        action="store_true",
+        default=False,
+        help="Whether the input is stranded",
+    )
+    pipeline_json_parser.add_argument(
+        "-f",
+        "--fragments",
+        action="store_true",
+        default=False,
+        help="Whether the input are fragments or reads.",
+    )
+    pipeline_json_parser.add_argument(
+        "-ps",
+        "--pos_shift",
+        type=int,
+        default=0,
+        help="How many bp to shift the + strand reads.",
+    )
+    pipeline_json_parser.add_argument(
+        "-ns",
+        "--neg_shift",
+        type=int,
+        default=0,
+        help="how many bp to shift the - strand reads.",
+    )
+    pipeline_json_parser.add_argument(
+        "-m",
+        "--motifs",
+        type=str,
+        default=None,
+        help="A motif database for marginalization and TF-MoDISco.",
+    )
+    pipeline_json_parser.add_argument(
+        "-o", "--output", type=str, help="The filename for the pipeline JSON."
+    )
+    pipeline_json_parser.add_argument(
+        "-pe",
+        "--paired_end",
+        action="store_true",
+        default=False,
+        help="Whether the input is paired-end.",
+    )
+    pipeline_json_parser.add_argument(
+        "-sf",
+        "--scale_factor",
+        default=1,
+        help="Whether to scale the read counts. 1 is no scaling.",
+    )
+
+    # Fit
+    fit_parser = subparsers.add_parser("fit", help="Fit a Cherimoya model.")
+    fit_parser.add_argument(
+        "-p",
+        "--parameters",
+        type=str,
+        required=True,
+        help="A JSON file containing the parameters for fitting the model.",
+    )
+
+    # Evaluate
+    evaluate_parser = subparsers.add_parser(
+        "evaluate", help="Evaluate a trained Cherimoya model."
+    )
+    evaluate_parser.add_argument(
+        "-p",
+        "--parameters",
+        type=str,
+        required=True,
+        help="A JSON file containing the parameters for making predictions.",
+    )
+
+    # Attribute
+    attribute_parser = subparsers.add_parser(
+        "attribute", help="Calculate attributions using a trained Cherimoya model."
+    )
+    attribute_parser.add_argument(
+        "-p",
+        "--parameters",
+        type=str,
+        required=True,
+        help="A JSON file containing the parameters for calculating attributions.",
+    )
+
+    # Seqlets
+    seqlets_parser = subparsers.add_parser(
+        "seqlets", help="Identify seqlets from attributions."
+    )
+    seqlets_parser.add_argument(
+        "-p",
+        "--parameters",
+        type=str,
+        required=True,
+        help="A JSON file containing the parameters for identifying seqlets.",
+    )
+
+    # Marginalize
+    marginalize_parser = subparsers.add_parser(
+        "marginalize", help="Run marginalizations given motifs."
+    )
+    marginalize_parser.add_argument(
+        "-p",
+        "--parameters",
+        type=str,
+        required=True,
+        help="A JSON file containing the parameters for running marginalizations.",
+    )
+
+    # Pipeline
+    pipeline_parser = subparsers.add_parser(
+        "pipeline", help="Run each step on the given files."
+    )
+    pipeline_parser.add_argument(
+        "-p",
+        "--parameters",
+        type=str,
+        required=True,
+        help="A JSON file containing the parameters used for each step.",
+    )
+
+    # Batch
+    batch_parser = subparsers.add_parser(
+        "batch", help="Run the pipeline in parallel using multiple GPUs."
+    )
+    batch_parser.add_argument(
+        "-p",
+        "--parameters",
+        type=str,
+        required=True,
+        help="A JSON file containing the parameters for fitting the model.",
+    )
+
+    # Install skill
+    install_skill_parser = subparsers.add_parser(
+        "install-skill",
+        help="Install the bundled Cherimoya agent skill for Claude Code.",
+    )
+    install_skill_parser.add_argument(
+        "-d",
+        "--directory",
+        type=str,
+        default=None,
+        help="Skills directory to install into. Default is ~/.claude/skills.",
+    )
+    install_skill_parser.add_argument(
+        "--symlink",
+        action="store_true",
+        default=False,
+        help="Symlink the packaged skill instead of copying it. Reflects "
+        "in-place edits, but breaks if the install location moves.",
+    )
+    install_skill_parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        default=False,
+        help="Overwrite an existing installation at the destination.",
+    )
+
+    return parser
 
 
 def main():
-	parser = argparse.ArgumentParser(description=desc)
-	parser.add_argument('--version', action='version',
-		version='cherimoya {}'.format(__version__))
-	subparsers = parser.add_subparsers(help=_help, required=True, dest='cmd')
+    parser = _setup_parsers()
+    args = parser.parse_args()
 
-	negatives.add_parser(subparsers)
-	pipeline_json.add_parser(subparsers)
-	batch.add_parser(subparsers)
-	fit.add_parser(subparsers)
-	evaluate.add_parser(subparsers)
-	attribute.add_parser(subparsers)
-	seqlets.add_parser(subparsers)
-	marginalize.add_parser(subparsers)
-	pipeline.add_parser(subparsers)
-	install_skill.add_parser(subparsers)
+    COMMANDS = {
+        "negatives": "negatives",
+        "pipeline-json": "pipeline_json",
+        "batch": "batch",
+        "fit": "fit",
+        "evaluate": "evaluate",
+        "attribute": "attribute",
+        "seqlets": "seqlets",
+        "marginalize": "marginalize",
+        "pipeline": "pipeline",
+        "install-skill": "install_skill",
+    }
 
-	args = parser.parse_args()
-	
-	commands = {
-		'negatives': negatives.run,
-		'pipeline-json': pipeline_json.run,
-		'batch': batch.run,
-		'fit': fit.run,
-		'evaluate': evaluate.run,
-		'attribute': attribute.run,
-		'seqlets': seqlets.run,
-		'marginalize': marginalize.run,
-		'pipeline': pipeline.run,
-		'install-skill': install_skill.run,
-	}
-
-	commands[args.cmd](args)
+    modname = COMMANDS.get(args.cmd)
+    if modname is None:
+        parser.error(f"unknown command: {args.cmd}")
+    mod = importlib.import_module(f".commands.{modname}", package=__package__)
+    mod.run(args)
 
 
-if __name__ == '__main__':
-	main()
+if __name__ == "__main__":
+    main()

--- a/cherimoya_cli/commands/attribute.py
+++ b/cherimoya_cli/commands/attribute.py
@@ -2,73 +2,68 @@
 # Author: Jacob Schreiber <jmschreiber91@gmail.com>
 
 
-def add_parser(subparsers):
-	parser = subparsers.add_parser("attribute",
-		help="Calculate attributions using a trained Cherimoya model.")
-	parser.add_argument("-p", "--parameters", type=str, required=True,
-		help="A JSON file containing the parameters for calculating attributions.")
-	return parser
-
-
 def run(args):
-	import sys
+    import sys
 
-	import numpy
-	import torch
+    import numpy
+    import torch
 
-	from tangermeme.io import extract_loci
-	from tangermeme.saturation_mutagenesis import saturation_mutagenesis
+    from tangermeme.io import extract_loci
+    from tangermeme.saturation_mutagenesis import saturation_mutagenesis
 
-	from cherimoya import Cherimoya
-	from cherimoya import ControlWrapper
-	from cherimoya import LogCountWrapper
-	from cherimoya import ProfileWrapper
-	from ..defaults import default_attribute_parameters
-	from ..utils import merge_parameters
+    from cherimoya import Cherimoya
+    from cherimoya import ControlWrapper
+    from cherimoya import LogCountWrapper
+    from cherimoya import ProfileWrapper
+    from ..defaults import default_attribute_parameters
+    from ..utils import merge_parameters
 
-	parameters = merge_parameters(args.parameters, default_attribute_parameters)
-	if parameters['skip']:
-		sys.exit()
+    parameters = merge_parameters(args.parameters, default_attribute_parameters)
+    if parameters["skip"]:
+        sys.exit()
 
-	###
+    ###
 
-	model = Cherimoya.load(parameters['model'], device=parameters['device'])
+    model = Cherimoya.load(parameters["model"], device=parameters["device"])
 
-	X, idxs = extract_loci(
-		sequences=parameters['sequences'],
-		loci=parameters['loci'],
-		chroms=parameters['chroms'],
-		max_jitter=0,
-		ignore=list('QWERYUIOPSDFHJKLZXVBNM'),
-		return_mask=True,
-		verbose=parameters['verbose']
-	)
+    X, idxs = extract_loci(
+        sequences=parameters["sequences"],
+        loci=parameters["loci"],
+        chroms=parameters["chroms"],
+        max_jitter=0,
+        ignore=list("QWERYUIOPSDFHJKLZXVBNM"),
+        return_mask=True,
+        verbose=parameters["verbose"],
+    )
 
-	n_idxs = X.sum(dim=(1, 2)) == X.shape[-1]
-	X = X[n_idxs]
+    n_idxs = X.sum(dim=(1, 2)) == X.shape[-1]
+    X = X[n_idxs]
 
-	idxs[~n_idxs] = False
+    idxs[~n_idxs] = False
 
-	model = ControlWrapper(model)
-	if parameters['output'] == 'counts':
-		wrapper = LogCountWrapper(model)
-	elif parameters['output'] == 'profile':
-		wrapper = ProfileWrapper(model)
-	else:
-		raise ValueError("output must be either `counts` or `profile`.")
+    model = ControlWrapper(model)
+    if parameters["output"] == "counts":
+        wrapper = LogCountWrapper(model)
+    elif parameters["output"] == "profile":
+        wrapper = ProfileWrapper(model)
+    else:
+        raise ValueError("output must be either `counts` or `profile`.")
 
-	mid = X.shape[-1] // 2
-	start, end = mid - 200, mid + 200
+    mid = X.shape[-1] // 2
+    start, end = mid - 200, mid + 200
 
-	X_attr = saturation_mutagenesis(wrapper, X,
-		dtype=parameters['dtype'],
-		device=parameters['device'],
-		batch_size=parameters['batch_size'],
-		verbose=parameters['verbose'],
-		hypothetical=True,
-		start=start, end=end
-	).float()
+    X_attr = saturation_mutagenesis(
+        wrapper,
+        X,
+        dtype=parameters["dtype"],
+        device=parameters["device"],
+        batch_size=parameters["batch_size"],
+        verbose=parameters["verbose"],
+        hypothetical=True,
+        start=start,
+        end=end,
+    ).float()
 
-	numpy.savez_compressed(parameters['ohe_filename'], X[:, :, start:end])
-	numpy.savez_compressed(parameters['attr_filename'], X_attr)
-	numpy.save(parameters['idx_filename'], idxs)
+    numpy.savez_compressed(parameters["ohe_filename"], X[:, :, start:end])
+    numpy.savez_compressed(parameters["attr_filename"], X_attr)
+    numpy.save(parameters["idx_filename"], idxs)

--- a/cherimoya_cli/commands/batch.py
+++ b/cherimoya_cli/commands/batch.py
@@ -2,89 +2,80 @@
 # Author: Jacob Schreiber <jmschreiber91@gmail.com>
 
 
-def add_parser(subparsers):
-	parser = subparsers.add_parser("batch", help="Run the pipeline in parallel using multiple GPUs.")
-	parser.add_argument("-p", "--parameters", type=str, required=True,
-		help="A JSON file containing the parameters for fitting the model.")
-	return parser
-
-
 def run(args):
-	import copy
-	import glob
-	import json
-	import subprocess
+    import copy
+    import glob
+    import json
+    import subprocess
 
-	import torch
+    import torch
 
-	from joblib import Parallel
-	from joblib import delayed
+    from joblib import Parallel
+    from joblib import delayed
 
-	from ..defaults import default_pipeline_parameters
-	from ..utils import merge_parameters
+    from ..defaults import default_pipeline_parameters
+    from ..utils import merge_parameters
 
-	parameters = merge_parameters(args.parameters, default_pipeline_parameters)
-	pname = parameters['name']
+    parameters = merge_parameters(args.parameters, default_pipeline_parameters)
+    pname = parameters["name"]
 
-	# Automatically extract parameters if wildcards are provided
-	if parameters['device'] == '*':
-		parameters['device'] = ['cuda:{}'.format(i) for i in range(torch.cuda.device_count())]
+    # Automatically extract parameters if wildcards are provided
+    if parameters["device"] == "*":
+        parameters["device"] = [
+            "cuda:{}".format(i) for i in range(torch.cuda.device_count())
+        ]
 
-	if '*' in parameters['signals']:
-		parameters['signals'] = list(glob.glob(parameters['signals']))
+    if "*" in parameters["signals"]:
+        parameters["signals"] = list(glob.glob(parameters["signals"]))
 
-		if parameters['name'] is None:
-			parameters['name'] = []
-			for name in parameters['signals']:
-				if name.endswith('.gz'):
-					name = '.'.join(name.split("/")[-1].split(".")[:-2])
-				else:
-					name = '.'.join(name.split("/")[-1].split(".")[:-1])
+        if parameters["name"] is None:
+            parameters["name"] = []
+            for name in parameters["signals"]:
+                if name.endswith(".gz"):
+                    name = ".".join(name.split("/")[-1].split(".")[:-2])
+                else:
+                    name = ".".join(name.split("/")[-1].split(".")[:-1])
 
-				parameters['name'].append(name)
+                parameters["name"].append(name)
 
+    print(parameters["signals"])
 
-	print(parameters['signals'])
+    # Check that the parameters are all correctly formatted
+    assert isinstance(parameters["name"], list)
+    assert isinstance(parameters["signals"], list)
+    assert len(parameters["name"]) == len(parameters["signals"])
+    for key in "loci", "controls", "negatives":
+        if parameters[key] is not None:
+            assert isinstance(parameters[key], list)
+            assert len(parameters["name"]) == len(parameters[key])
 
+    # Create and run each of the JSONs
+    def _create_and_run_json(parameters, i):
+        name = parameters["name"][i]
 
-	# Check that the parameters are all correctly formatted
-	assert isinstance(parameters['name'], list)
-	assert isinstance(parameters['signals'], list)
-	assert len(parameters['name']) == len(parameters['signals'])
-	for key in 'loci', 'controls', 'negatives':
-		if parameters[key] is not None:
-			assert isinstance(parameters[key], list)
-			assert len(parameters['name']) == len(parameters[key])
+        pipeline_json = copy.deepcopy(parameters)
+        pipeline_json["name"] = name
+        pipeline_json["device"] = parameters["device"][i % len(parameters["device"])]
+        pipeline_json["signals"] = parameters["signals"][i]
 
+        for key in "loci", "negatives", "controls":
+            parameter = parameters[key]
+            pipeline_json[key] = None if parameter is None else parameter[i]
 
-	# Create and run each of the JSONs
-	def _create_and_run_json(parameters, i):
-		name = parameters['name'][i]
+        for key in "signals", "loci", "negatives", "controls":
+            value = pipeline_json[key]
 
-		pipeline_json = copy.deepcopy(parameters)
-		pipeline_json['name'] = name
-		pipeline_json['device'] = parameters['device'][i % len(parameters['device'])]
-		pipeline_json['signals'] = parameters['signals'][i]
+            if value is not None and not isinstance(value, list):
+                pipeline_json[key] = [value]
 
-		for key in 'loci', 'negatives', 'controls':
-			parameter = parameters[key]
-			pipeline_json[key] = None if parameter is None else parameter[i]
+        jname = "{}.pipeline.json".format(name)
+        with open(jname, "w") as outfile:
+            outfile.write(json.dumps(pipeline_json, indent=4))
 
-		for key in 'signals', 'loci', 'negatives', 'controls':
-			value = pipeline_json[key]
+        subprocess.run(["cherimoya", "pipeline", "-p", jname], check=True)
 
-			if value is not None and not isinstance(value, list):
-				pipeline_json[key] = [value]
+    n = len(parameters["name"])
+    n_devices = len(parameters["device"])
+    f = delayed(_create_and_run_json)
 
-		jname = "{}.pipeline.json".format(name)
-		with open(jname, "w") as outfile:
-			outfile.write(json.dumps(pipeline_json, indent=4))
-
-		subprocess.run(["cherimoya", "pipeline", "-p", jname], check=True)
-
-
-	n = len(parameters['name'])
-	n_devices = len(parameters['device'])
-	f = delayed(_create_and_run_json)
-
-	Parallel(n_jobs=n_devices)(f(parameters, i) for i in range(n))
+    Parallel(n_jobs=n_devices)(f(parameters, i) for i in range(n))

--- a/cherimoya_cli/commands/evaluate.py
+++ b/cherimoya_cli/commands/evaluate.py
@@ -2,131 +2,142 @@
 # Author: Jacob Schreiber <jmschreiber91@gmail.com>
 
 
-def add_parser(subparsers):
-	parser = subparsers.add_parser("evaluate",
-		help="Evaluate a trained Cherimoya model.")
-	parser.add_argument("-p", "--parameters", type=str, required=True,
-		help="A JSON file containing the parameters for making predictions.")
-	return parser
-
-
 def run(args):
-	import sys
+    import sys
 
-	import torch
+    import torch
 
-	from tangermeme.io import extract_loci
-	from tangermeme.predict import predict
+    from tangermeme.io import extract_loci
+    from tangermeme.predict import predict
 
-	from cherimoya import Cherimoya
-	from cherimoya import ControlWrapper
-	from cherimoya.io import normalize_signal_groups
-	from cherimoya.performance import calculate_performance_measures
-	from ..defaults import default_evaluate_parameters
-	from ..utils import merge_parameters
+    from cherimoya import Cherimoya
+    from cherimoya import ControlWrapper
+    from cherimoya.io import normalize_signal_groups
+    from cherimoya.performance import calculate_performance_measures
+    from ..defaults import default_evaluate_parameters
+    from ..utils import merge_parameters
 
-	parameters = merge_parameters(args.parameters, default_evaluate_parameters)
-	if parameters['skip']:
-		sys.exit()
+    parameters = merge_parameters(args.parameters, default_evaluate_parameters)
+    if parameters["skip"]:
+        sys.exit()
 
-	# Flatten any structured (list-of-lists) signals/controls so they
-	# can be handed to extract_loci. The model's own signal_groups
-	# (recovered below from the loaded checkpoint) drives count pooling
-	# under calculate_performance_measures.
-	signal_files, signal_groups = normalize_signal_groups(parameters['signals'])
-	control_files, _ = normalize_signal_groups(parameters['controls'])
-	parameters['signals'] = signal_files
-	parameters['controls'] = control_files
+    # Flatten any structured (list-of-lists) signals/controls so they
+    # can be handed to extract_loci. The model's own signal_groups
+    # (recovered below from the loaded checkpoint) drives count pooling
+    # under calculate_performance_measures.
+    signal_files, signal_groups = normalize_signal_groups(parameters["signals"])
+    control_files, _ = normalize_signal_groups(parameters["controls"])
+    parameters["signals"] = signal_files
+    parameters["controls"] = control_files
 
-	measure_names = ['profile_mnll', 'profile_jsd', 'profile_pearson',
-		'profile_spearman', 'count_pearson', 'count_spearman', 'count_mse']
+    measure_names = [
+        "profile_mnll",
+        "profile_jsd",
+        "profile_pearson",
+        "profile_spearman",
+        "count_pearson",
+        "count_spearman",
+        "count_mse",
+    ]
 
-	###
+    ###
 
-	model = Cherimoya.load(parameters['model'], device=parameters['device'])
+    model = Cherimoya.load(parameters["model"], device=parameters["device"])
 
-	examples = extract_loci(
-		sequences=parameters['sequences'],
-		signals=parameters['signals'],
-		in_signals=parameters['controls'],
-		loci=parameters['loci'],
-		chroms=parameters['chroms'],
-		in_window=parameters['in_window'],
-		out_window=parameters['out_window'],
-		exclusion_lists=parameters['exclusion_lists'],
-		max_jitter=0,
-		ignore=list('QWERYUIOPSDFHJKLZXVBNM'),
-		verbose=parameters['verbose']
-	)
+    examples = extract_loci(
+        sequences=parameters["sequences"],
+        signals=parameters["signals"],
+        in_signals=parameters["controls"],
+        loci=parameters["loci"],
+        chroms=parameters["chroms"],
+        in_window=parameters["in_window"],
+        out_window=parameters["out_window"],
+        exclusion_lists=parameters["exclusion_lists"],
+        max_jitter=0,
+        ignore=list("QWERYUIOPSDFHJKLZXVBNM"),
+        verbose=parameters["verbose"],
+    )
 
-	if parameters['controls'] == None:
-		X, y = examples
-		X_ctl = None
-		if model.n_control_tracks > 0:
-			model = ControlWrapper(model)
-	else:
-		X, y, X_ctl = examples
-		X_ctl = (X_ctl,)
+    if parameters["controls"] == None:
+        X, y = examples
+        X_ctl = None
+        if model.n_control_tracks > 0:
+            model = ControlWrapper(model)
+    else:
+        X, y, X_ctl = examples
+        X_ctl = (X_ctl,)
 
-	y_hat_logits, y_hat_logcounts = predict(model, X, args=X_ctl,
-		batch_size=parameters['batch_size'], device=parameters['device'],
-		dtype=parameters['dtype'], verbose=parameters['verbose'])
+    y_hat_logits, y_hat_logcounts = predict(
+        model,
+        X,
+        args=X_ctl,
+        batch_size=parameters["batch_size"],
+        device=parameters["device"],
+        dtype=parameters["dtype"],
+        verbose=parameters["verbose"],
+    )
 
-	if parameters['reverse_complement_average']:
-		X_rc = torch.flip(X, dims=(-1, -2))
-		X_ctl_rc = None if X_ctl is None else (torch.flip(X_ctl[0], dims=(-1, -2)),)
+    if parameters["reverse_complement_average"]:
+        X_rc = torch.flip(X, dims=(-1, -2))
+        X_ctl_rc = None if X_ctl is None else (torch.flip(X_ctl[0], dims=(-1, -2)),)
 
-		y_hat_logits_rc, y_hat_logcounts_rc = predict(model, X_rc, args=X_ctl_rc,
-			batch_size=parameters['batch_size'], device=parameters['device'],
-			dtype=parameters['dtype'], verbose=parameters['verbose'])
+        y_hat_logits_rc, y_hat_logcounts_rc = predict(
+            model,
+            X_rc,
+            args=X_ctl_rc,
+            batch_size=parameters["batch_size"],
+            device=parameters["device"],
+            dtype=parameters["dtype"],
+            verbose=parameters["verbose"],
+        )
 
-		y_hat_logits_rc = torch.flip(y_hat_logits_rc, dims=(-1, -2))
-		y_hat_logits = (y_hat_logits + y_hat_logits_rc) / 2
-		y_hat_logcounts = (y_hat_logcounts + y_hat_logcounts_rc) / 2
+        y_hat_logits_rc = torch.flip(y_hat_logits_rc, dims=(-1, -2))
+        y_hat_logits = (y_hat_logits + y_hat_logits_rc) / 2
+        y_hat_logcounts = (y_hat_logcounts + y_hat_logcounts_rc) / 2
 
-	# Prefer the model's own grouping over whatever the caller passed
-	# in the JSON — the checkpoint is authoritative about how its count
-	# head is laid out.
-	model_signal_groups = getattr(model, 'signal_groups', None)
-	if model_signal_groups is None:
-		model_signal_groups = signal_groups
+    # Prefer the model's own grouping over whatever the caller passed
+    # in the JSON — the checkpoint is authoritative about how its count
+    # head is laid out.
+    model_signal_groups = getattr(model, "signal_groups", None)
+    if model_signal_groups is None:
+        model_signal_groups = signal_groups
 
-	measures = calculate_performance_measures(y_hat_logits, y,
-		y_hat_logcounts, signal_groups=model_signal_groups)
+    measures = calculate_performance_measures(
+        y_hat_logits, y, y_hat_logcounts, signal_groups=model_signal_groups
+    )
 
-	# Build one row per signal group. Profile metrics come back shape
-	# (n_loci, sum(signal_groups)) — average over each group's channel
-	# slice and the locus dim. Count metrics already arrive at
-	# (n_groups,) when signal_groups is given, so the per-group value
-	# is just the i-th element.
-	#
-	# For a single-group model the output reduces to one row that is
-	# byte-identical to the legacy `.mean()`-over-everything line:
-	# the profile slice is the whole tensor (one group spans every
-	# channel), and the count vector has length 1.
-	groups = model_signal_groups or [y_hat_logits.shape[1]]
-	rows = []
-	offset = 0
-	for i, g in enumerate(groups):
-		row = []
-		for name in measure_names:
-			value = measures[name]
-			if name.startswith('profile_'):
-				row.append(value[:, offset:offset+g].mean().item())
-			else:
-				row.append(value[i].item() if value.ndim >= 1
-					else value.item())
-		rows.append(row)
-		offset += g
+    # Build one row per signal group. Profile metrics come back shape
+    # (n_loci, sum(signal_groups)) — average over each group's channel
+    # slice and the locus dim. Count metrics already arrive at
+    # (n_groups,) when signal_groups is given, so the per-group value
+    # is just the i-th element.
+    #
+    # For a single-group model the output reduces to one row that is
+    # byte-identical to the legacy `.mean()`-over-everything line:
+    # the profile slice is the whole tensor (one group spans every
+    # channel), and the count vector has length 1.
+    groups = model_signal_groups or [y_hat_logits.shape[1]]
+    rows = []
+    offset = 0
+    for i, g in enumerate(groups):
+        row = []
+        for name in measure_names:
+            value = measures[name]
+            if name.startswith("profile_"):
+                row.append(value[:, offset : offset + g].mean().item())
+            else:
+                row.append(value[i].item() if value.ndim >= 1 else value.item())
+        rows.append(row)
+        offset += g
 
-	def _format_rows():
-		yield "\t".join(measure_names)
-		for row in rows:
-			yield "\t".join(str(v) for v in row)
+    def _format_rows():
+        yield "\t".join(measure_names)
+        for row in rows:
+            yield "\t".join(str(v) for v in row)
 
-	with open(parameters['performance_filename'], "w") as outfile:
-		outfile.write("\n".join(_format_rows()))
+    with open(parameters["performance_filename"], "w") as outfile:
+        outfile.write("\n".join(_format_rows()))
 
-	if parameters['verbose']:
-		for line in _format_rows():
-			print(line)
+    if parameters["verbose"]:
+        for line in _format_rows():
+            print(line)

--- a/cherimoya_cli/commands/fit.py
+++ b/cherimoya_cli/commands/fit.py
@@ -2,259 +2,276 @@
 # Author: Jacob Schreiber <jmschreiber91@gmail.com>
 
 
-def add_parser(subparsers):
-	parser = subparsers.add_parser("fit", help="Fit a Cherimoya model.")
-	parser.add_argument("-p", "--parameters", type=str, required=True,
-		help="A JSON file containing the parameters for fitting the model.")
-	return parser
-
-
 def run(args):
-	import argparse
-	import copy
-	import os
-	import sys
-	import json
+    import argparse
+    import copy
+    import os
+    import sys
+    import json
 
-	os.environ['TORCH_CUDNN_V8_API_ENABLED'] = '1'
+    os.environ["TORCH_CUDNN_V8_API_ENABLED"] = "1"
 
-	import torch
-	torch.backends.cudnn.benchmark = True
-	torch.set_float32_matmul_precision('high')
+    import torch
 
-	from torch.optim import Muon
-	from torch.optim.lr_scheduler import (LinearLR, CosineAnnealingLR,
-		ConstantLR, SequentialLR)
+    torch.backends.cudnn.benchmark = True
+    torch.set_float32_matmul_precision("high")
 
-	from cherimoya import Cherimoya
-	from cherimoya.io import PeakGenerator, normalize_signal_groups
+    from torch.optim import Muon
+    from torch.optim.lr_scheduler import (
+        LinearLR,
+        CosineAnnealingLR,
+        ConstantLR,
+        SequentialLR,
+    )
 
-	from tangermeme.io import extract_loci
+    from cherimoya import Cherimoya
+    from cherimoya.io import PeakGenerator, normalize_signal_groups
 
-	from . import evaluate as evaluate_cmd
-	from ..defaults import default_fit_parameters
-	from ..utils import merge_parameters
+    from tangermeme.io import extract_loci
 
-	parameters = merge_parameters(args.parameters, default_fit_parameters)
-	if parameters['skip']:
-		sys.exit()
+    from . import evaluate as evaluate_cmd
+    from ..defaults import default_fit_parameters
+    from ..utils import merge_parameters
 
-	# Resolve grouped/flat signal specs into a flat list of files plus
-	# the per-group sizes. The flat list is what extract_loci and the
-	# `bam2bw`-style tooling need; the group sizes determine the
-	# channel permutation used under RC and the number of count
-	# predictions. We deliberately do NOT mutate ``parameters['signals']``
-	# here — the structured form (e.g. ``[[plus.bw, minus.bw]]``) is what
-	# the downstream evaluate JSON needs to re-parse the grouping
-	# correctly. Mutating to the flat form here would silently
-	# re-interpret a stranded pair as two unstranded channels in the
-	# evaluate step.
-	signal_files, signal_groups = normalize_signal_groups(parameters['signals'])
-	control_files, control_groups = normalize_signal_groups(parameters['controls'])
+    parameters = merge_parameters(args.parameters, default_fit_parameters)
+    if parameters["skip"]:
+        sys.exit()
 
-	if parameters['verbose']:
-		print("Training Chroms: ", parameters['training_chroms'])
-		print("Vaidation Chroms: ", parameters['validation_chroms'])
+    # Resolve grouped/flat signal specs into a flat list of files plus
+    # the per-group sizes. The flat list is what extract_loci and the
+    # `bam2bw`-style tooling need; the group sizes determine the
+    # channel permutation used under RC and the number of count
+    # predictions. We deliberately do NOT mutate ``parameters['signals']``
+    # here — the structured form (e.g. ``[[plus.bw, minus.bw]]``) is what
+    # the downstream evaluate JSON needs to re-parse the grouping
+    # correctly. Mutating to the flat form here would silently
+    # re-interpret a stranded pair as two unstranded channels in the
+    # evaluate step.
+    signal_files, signal_groups = normalize_signal_groups(parameters["signals"])
+    control_files, control_groups = normalize_signal_groups(parameters["controls"])
 
-		print("\nLoading peaks from: ", parameters['loci'])
-		print("Loading negatives from: ", parameters['negatives'])
-		print("Loading sequence from: ", parameters['sequences'])
-		print("Loading signal from: ", parameters['signals'])
-		print("Loading controls from: ", parameters['controls'])
-		print("Loading exclusion list from: ", parameters['exclusion_lists'])
-		print()
+    if parameters["verbose"]:
+        print("Training Chroms: ", parameters["training_chroms"])
+        print("Vaidation Chroms: ", parameters["validation_chroms"])
 
+        print("\nLoading peaks from: ", parameters["loci"])
+        print("Loading negatives from: ", parameters["negatives"])
+        print("Loading sequence from: ", parameters["sequences"])
+        print("Loading signal from: ", parameters["signals"])
+        print("Loading controls from: ", parameters["controls"])
+        print("Loading exclusion list from: ", parameters["exclusion_lists"])
+        print()
 
-	###
+    ###
 
-	training_data = PeakGenerator(
-		peaks=parameters['loci'],
-		negatives=parameters['negatives'],
-		sequences=parameters['sequences'],
-		signals=parameters['signals'],
-		controls=parameters['controls'],
-		chroms=parameters['training_chroms'],
-		in_window=parameters['in_window'],
-		out_window=parameters['out_window'],
-		max_jitter=parameters['max_jitter'],
-		negative_ratio=parameters['negative_ratio'],
-		reverse_complement=parameters['reverse_complement'],
-		summits=parameters['summits'],
-		exclusion_lists=parameters['exclusion_lists'],
-		random_state=parameters['random_state'],
-		batch_size=parameters['batch_size'],
-		num_workers=parameters['num_workers'],
-		verbose=parameters['verbose'],
-		signal_groups=signal_groups,
-		control_groups=control_groups,
-	)
+    training_data = PeakGenerator(
+        peaks=parameters["loci"],
+        negatives=parameters["negatives"],
+        sequences=parameters["sequences"],
+        signals=parameters["signals"],
+        controls=parameters["controls"],
+        chroms=parameters["training_chroms"],
+        in_window=parameters["in_window"],
+        out_window=parameters["out_window"],
+        max_jitter=parameters["max_jitter"],
+        negative_ratio=parameters["negative_ratio"],
+        reverse_complement=parameters["reverse_complement"],
+        summits=parameters["summits"],
+        exclusion_lists=parameters["exclusion_lists"],
+        random_state=parameters["random_state"],
+        batch_size=parameters["batch_size"],
+        num_workers=parameters["num_workers"],
+        verbose=parameters["verbose"],
+        signal_groups=signal_groups,
+        control_groups=control_groups,
+    )
 
-	valid_data = extract_loci(
-		sequences=parameters['sequences'],
-		signals=signal_files,
-		in_signals=control_files,
-		loci=parameters['loci'],
-		chroms=parameters['validation_chroms'],
-		in_window=parameters['in_window'],
-		out_window=parameters['out_window'],
-		max_jitter=0,
-		exclusion_lists=parameters['exclusion_lists'],
-		ignore=list('QWERYUIOPSDFHJKLZXVBNM'),
-		verbose=parameters['verbose']
-	)
+    valid_data = extract_loci(
+        sequences=parameters["sequences"],
+        signals=signal_files,
+        in_signals=control_files,
+        loci=parameters["loci"],
+        chroms=parameters["validation_chroms"],
+        in_window=parameters["in_window"],
+        out_window=parameters["out_window"],
+        max_jitter=0,
+        exclusion_lists=parameters["exclusion_lists"],
+        ignore=list("QWERYUIOPSDFHJKLZXVBNM"),
+        verbose=parameters["verbose"],
+    )
 
-	if parameters['verbose']:
-		print("\nTraining Set Peaks: ", training_data.dataset.peak_sequences.shape[0])
-		print("Training Set Negatives: ", training_data.dataset.negative_sequences.shape[0])
-		print("Validation Set Size: ", valid_data[0].shape[0], "\n")
+    if parameters["verbose"]:
+        print("\nTraining Set Peaks: ", training_data.dataset.peak_sequences.shape[0])
+        print(
+            "Training Set Negatives: ",
+            training_data.dataset.negative_sequences.shape[0],
+        )
+        print("Validation Set Size: ", valid_data[0].shape[0], "\n")
 
+    if parameters["verbose"]:
+        print("Negative Ratio: 1:{:4.4} pos:neg\n".format(parameters["negative_ratio"]))
 
-	if parameters['verbose']:
-		print("Negative Ratio: 1:{:4.4} pos:neg\n".format(
-			parameters['negative_ratio']))
+    ###
 
-	###
+    if control_files is not None:
+        valid_sequences, valid_signals, valid_controls = valid_data
+        n_control_tracks = len(control_files)
+    else:
+        valid_sequences, valid_signals = valid_data
+        valid_controls = None
+        n_control_tracks = 0
 
-	if control_files is not None:
-		valid_sequences, valid_signals, valid_controls = valid_data
-		n_control_tracks = len(control_files)
-	else:
-		valid_sequences, valid_signals = valid_data
-		valid_controls = None
-		n_control_tracks = 0
+    trimming = (parameters["in_window"] - parameters["out_window"]) // 2
 
-	trimming = (parameters['in_window'] - parameters['out_window']) // 2
+    model = Cherimoya(
+        n_filters=parameters["n_filters"],
+        n_layers=parameters["n_layers"],
+        signal_groups=signal_groups,
+        n_control_tracks=n_control_tracks,
+        expansion=parameters["expansion"],
+        residual_scale=parameters["residual_scale"],
+        trimming=trimming,
+        name=parameters["name"],
+        verbose=parameters["verbose"],
+    ).to(parameters["device"])
 
-	model = Cherimoya(
-		n_filters=parameters['n_filters'],
-		n_layers=parameters['n_layers'],
-		signal_groups=signal_groups,
-		n_control_tracks=n_control_tracks,
-		expansion=parameters['expansion'],
-		residual_scale=parameters['residual_scale'],
-		trimming=trimming,
-		name=parameters['name'],
-		verbose=parameters['verbose']
-	).to(parameters['device'])
+    if parameters["verbose"]:
+        print(
+            "Model has {} dilated layers and {} filters".format(
+                parameters["n_layers"], parameters["n_filters"]
+            )
+        )
+        print(
+            "Model has {} trainable parameters.\n".format(
+                sum(p.numel() for p in model.parameters() if p.requires_grad)
+            )
+        )
 
-	if parameters['verbose']:
-		print("Model has {} dilated layers and {} filters".format(
-			parameters['n_layers'], parameters['n_filters'])
-		)
-		print("Model has {} trainable parameters.\n".format(
-			sum(p.numel() for p in model.parameters() if p.requires_grad))
-		)
+    n_warmup_epochs = parameters["n_warmup_epochs"]
+    max_epochs = parameters["max_epochs"]
+    num_warmup_iters = len(training_data) * n_warmup_epochs
+    num_decay_iters = len(training_data) * max(1, max_epochs - n_warmup_epochs)
 
-	n_warmup_epochs = parameters['n_warmup_epochs']
-	max_epochs = parameters['max_epochs']
-	num_warmup_iters = len(training_data) * n_warmup_epochs
-	num_decay_iters = len(training_data) * max(1, max_epochs - n_warmup_epochs)
+    # Muon takes 2D projection weights inside Cheri Blocks
+    # (linear1/linear2.weight). ``conv_weight`` is 2D but lives on the
+    # depth-wise dilated path, not a projection matmul, and is routed to
+    # AdamW. ``lw0`` / ``lw1`` are routed by exact name to SGD.
+    muon_params = []
+    adam_params = []
+    lw_params = []
+    for name, p in model.named_parameters():
+        if name in ("lw0", "lw1"):
+            lw_params.append(p)
+        elif (
+            p.ndim == 2
+            and "weight" in name
+            and name != "linear.weight"
+            and "conv_weight" not in name
+        ):
+            muon_params.append(p)
+        else:
+            adam_params.append(p)
 
-	# Muon takes 2D projection weights inside Cheri Blocks
-	# (linear1/linear2.weight). ``conv_weight`` is 2D but lives on the
-	# depth-wise dilated path, not a projection matmul, and is routed to
-	# AdamW. ``lw0`` / ``lw1`` are routed by exact name to SGD.
-	muon_params = []
-	adam_params = []
-	lw_params = []
-	for name, p in model.named_parameters():
-		if name in ("lw0", "lw1"):
-			lw_params.append(p)
-		elif (p.ndim == 2 and "weight" in name and name != "linear.weight"
-				and "conv_weight" not in name):
-			muon_params.append(p)
-		else:
-			adam_params.append(p)
+    muon_optimizer = Muon(
+        muon_params, lr=parameters["muon_lr"], weight_decay=parameters["muon_wd"]
+    )
 
-	muon_optimizer = Muon(
-		muon_params,
-		lr=parameters['muon_lr'],
-		weight_decay=parameters['muon_wd']
-	)
+    muon_warmup_scheduler = LinearLR(
+        muon_optimizer, start_factor=0.01, total_iters=num_warmup_iters
+    )
+    muon_decay_scheduler = CosineAnnealingLR(
+        muon_optimizer, T_max=num_decay_iters, eta_min=1e-5
+    )
+    muon_scheduler = SequentialLR(
+        muon_optimizer,
+        schedulers=[muon_warmup_scheduler, muon_decay_scheduler],
+        milestones=[num_warmup_iters],
+    )
 
-	muon_warmup_scheduler = LinearLR(muon_optimizer, start_factor=0.01,
-		total_iters=num_warmup_iters)
-	muon_decay_scheduler = CosineAnnealingLR(muon_optimizer,
-		T_max=num_decay_iters, eta_min=1e-5)
-	muon_scheduler = SequentialLR(
-		muon_optimizer,
-		schedulers=[muon_warmup_scheduler, muon_decay_scheduler],
-		milestones=[num_warmup_iters]
-	)
+    adam_optimizer = torch.optim.AdamW(
+        adam_params, lr=parameters["adam_lr"], weight_decay=parameters["adam_wd"]
+    )
+    adam_warmup_scheduler = LinearLR(
+        adam_optimizer, start_factor=0.01, total_iters=num_warmup_iters
+    )
+    adam_decay_scheduler = CosineAnnealingLR(
+        adam_optimizer, T_max=num_decay_iters, eta_min=1e-5
+    )
+    adam_scheduler = SequentialLR(
+        adam_optimizer,
+        schedulers=[adam_warmup_scheduler, adam_decay_scheduler],
+        milestones=[num_warmup_iters],
+    )
 
-	adam_optimizer = torch.optim.AdamW(
-		adam_params,
-		lr=parameters['adam_lr'],
-		weight_decay=parameters['adam_wd']
-	)
-	adam_warmup_scheduler = LinearLR(adam_optimizer, start_factor=0.01,
-		total_iters=num_warmup_iters)
-	adam_decay_scheduler = CosineAnnealingLR(adam_optimizer,
-		T_max=num_decay_iters, eta_min=1e-5)
-	adam_scheduler = SequentialLR(
-		adam_optimizer,
-		schedulers=[adam_warmup_scheduler, adam_decay_scheduler],
-		milestones=[num_warmup_iters]
-	)
+    # lw_optimizer holds only lw0/lw1. ``ConstantLR(factor=1.0)`` after
+    # the warmup phase keeps the lr flat for the rest of training — we
+    # deliberately do not cosine-decay the Kendall loss-balancing weights.
+    lw_optimizer = torch.optim.SGD(
+        lw_params,
+        lr=parameters["lw_lr"],
+        weight_decay=parameters["lw_wd"],
+        momentum=parameters["lw_momentum"],
+    )
+    lw_warmup_scheduler = LinearLR(
+        lw_optimizer, start_factor=0.01, total_iters=num_warmup_iters
+    )
+    lw_constant_scheduler = ConstantLR(lw_optimizer, factor=1.0, total_iters=1)
+    lw_scheduler = SequentialLR(
+        lw_optimizer,
+        schedulers=[lw_warmup_scheduler, lw_constant_scheduler],
+        milestones=[num_warmup_iters],
+    )
 
-	# lw_optimizer holds only lw0/lw1. ``ConstantLR(factor=1.0)`` after
-	# the warmup phase keeps the lr flat for the rest of training — we
-	# deliberately do not cosine-decay the Kendall loss-balancing weights.
-	lw_optimizer = torch.optim.SGD(
-		lw_params,
-		lr=parameters['lw_lr'],
-		weight_decay=parameters['lw_wd'],
-		momentum=parameters['lw_momentum']
-	)
-	lw_warmup_scheduler = LinearLR(lw_optimizer, start_factor=0.01,
-		total_iters=num_warmup_iters)
-	lw_constant_scheduler = ConstantLR(lw_optimizer, factor=1.0,
-		total_iters=1)
-	lw_scheduler = SequentialLR(
-		lw_optimizer,
-		schedulers=[lw_warmup_scheduler, lw_constant_scheduler],
-		milestones=[num_warmup_iters]
-	)
+    if parameters["verbose"]:
+        print(
+            "Muon Optimizer: lr={}, wd={}".format(
+                parameters["muon_lr"], parameters["muon_wd"]
+            )
+        )
+        print(
+            "AdamW Optimizer: lr={}, wd={}".format(
+                parameters["adam_lr"], parameters["adam_wd"]
+            )
+        )
+        print(
+            "SGD Optimizer (lw): lr={}, wd={}, momentum={}\n".format(
+                parameters["lw_lr"], parameters["lw_wd"], parameters["lw_momentum"]
+            )
+        )
 
-	if parameters['verbose']:
-		print("Muon Optimizer: lr={}, wd={}".format(parameters['muon_lr'],
-													parameters['muon_wd']))
-		print("AdamW Optimizer: lr={}, wd={}".format(parameters['adam_lr'],
-													 parameters['adam_wd']))
-		print("SGD Optimizer (lw): lr={}, wd={}, momentum={}\n".format(
-			parameters['lw_lr'], parameters['lw_wd'],
-			parameters['lw_momentum']))
-		  
-	###
+    ###
 
-	
+    model.fit(
+        training_data,
+        muon_optimizer,
+        adam_optimizer,
+        lw_optimizer,
+        muon_scheduler,
+        adam_scheduler,
+        lw_scheduler,
+        X_valid=valid_sequences,
+        X_ctl_valid=valid_controls,
+        y_valid=valid_signals,
+        max_epochs=max_epochs,
+        batch_size=parameters["batch_size"],
+        early_stopping=parameters["early_stopping"],
+        dtype=parameters["dtype"],
+        device=parameters["device"],
+    )
 
-	model.fit(training_data,
-		muon_optimizer, adam_optimizer, lw_optimizer,
-		muon_scheduler, adam_scheduler, lw_scheduler,
-		X_valid=valid_sequences,
-		X_ctl_valid=valid_controls,
-		y_valid=valid_signals,
-		max_epochs=max_epochs,
-		batch_size=parameters['batch_size'],
-		early_stopping=parameters['early_stopping'],
-		dtype=parameters['dtype'],
-		device=parameters['device'])
+    ### Evaluate Model
 
-	### Evaluate Model
+    model_name = parameters["name"] or model.name
 
-	model_name = parameters['name'] or model.name
+    evaluate_parameters = copy.deepcopy(parameters)
+    evaluate_parameters["chroms"] = parameters["validation_chroms"]
+    evaluate_parameters["max_jitter"] = 0
+    evaluate_parameters["reverse_complement"] = False
+    evaluate_parameters["model"] = model_name + ".torch"
+    evaluate_parameters["performance_filename"] = model_name + ".performance.tsv"
 
-	evaluate_parameters = copy.deepcopy(parameters)
-	evaluate_parameters['chroms'] = parameters['validation_chroms']
-	evaluate_parameters['max_jitter'] = 0
-	evaluate_parameters['reverse_complement'] = False
-	evaluate_parameters['model'] = model_name + '.torch'
-	evaluate_parameters['performance_filename'] = model_name + '.performance.tsv'
+    fname = "{}.evaluate.json".format(model_name)
+    with open(fname, "w") as outfile:
+        outfile.write(json.dumps(evaluate_parameters, sort_keys=True, indent=4))
 
-
-	fname = "{}.evaluate.json".format(model_name)
-	with open(fname, "w") as outfile:
-		outfile.write(json.dumps(evaluate_parameters, sort_keys=True, indent=4))
-
-	evaluate_cmd.run(argparse.Namespace(parameters=fname))
+    evaluate_cmd.run(argparse.Namespace(parameters=fname))

--- a/cherimoya_cli/commands/marginalize.py
+++ b/cherimoya_cli/commands/marginalize.py
@@ -2,62 +2,57 @@
 # Author: Jacob Schreiber <jmschreiber91@gmail.com>
 
 
-def add_parser(subparsers):
-	parser = subparsers.add_parser("marginalize",
-		help="Run marginalizations given motifs.")
-	parser.add_argument("-p", "--parameters", type=str, required=True,
-		help="A JSON file containing the parameters for running marginalizations.")
-	return parser
-
-
 def run(args):
-	import sys
+    import sys
 
-	import numpy
-	import torch
+    import numpy
+    import torch
 
-	from bpnetlite.marginalize import marginalization_report
-	from tangermeme.io import extract_loci
+    from bpnetlite.marginalize import marginalization_report
+    from tangermeme.io import extract_loci
 
-	from cherimoya import Cherimoya
-	from cherimoya import ControlWrapper
-	from ..defaults import default_marginalize_parameters
-	from ..utils import merge_parameters
+    from cherimoya import Cherimoya
+    from cherimoya import ControlWrapper
+    from ..defaults import default_marginalize_parameters
+    from ..utils import merge_parameters
 
-	parameters = merge_parameters(args.parameters,
-		default_marginalize_parameters)
-	if parameters['skip']:
-		sys.exit()
+    parameters = merge_parameters(args.parameters, default_marginalize_parameters)
+    if parameters["skip"]:
+        sys.exit()
 
-	###
+    ###
 
-	model = Cherimoya.load(parameters['model'], device=parameters['device'])
+    model = Cherimoya.load(parameters["model"], device=parameters["device"])
 
-	if model.n_control_tracks > 0:
-		model = ControlWrapper(model)
+    if model.n_control_tracks > 0:
+        model = ControlWrapper(model)
 
-	X = extract_loci(
-		sequences=parameters['sequences'],
-		loci=parameters['loci'],
-		chroms=parameters['chroms'],
-		max_jitter=0,
-		ignore=list('QWERYUIOPSDFHJKLZXVBNM'),
-		n_loci=parameters['n_loci'],
-		verbose=parameters['verbose']
-	).float()
+    X = extract_loci(
+        sequences=parameters["sequences"],
+        loci=parameters["loci"],
+        chroms=parameters["chroms"],
+        max_jitter=0,
+        ignore=list("QWERYUIOPSDFHJKLZXVBNM"),
+        n_loci=parameters["n_loci"],
+        verbose=parameters["verbose"],
+    ).float()
 
-	if parameters['shuffle'] == True:
-		idxs = numpy.arange(X.shape[0])
-		numpy.random.shuffle(idxs)
-		X = X[idxs]
+    if parameters["shuffle"] == True:
+        idxs = numpy.arange(X.shape[0])
+        numpy.random.shuffle(idxs)
+        X = X[idxs]
 
-	if parameters['n_loci'] is not None:
-		X = X[:parameters['n_loci']]
+    if parameters["n_loci"] is not None:
+        X = X[: parameters["n_loci"]]
 
-	marginalization_report(model, parameters['motifs'], X,
-		parameters['output_filename'],
-		attributions=parameters['attributions'],
-		batch_size=parameters['batch_size'],
-		minimal=parameters['minimal'],
-		device=parameters['device'],
-		verbose=parameters['verbose'])
+    marginalization_report(
+        model,
+        parameters["motifs"],
+        X,
+        parameters["output_filename"],
+        attributions=parameters["attributions"],
+        batch_size=parameters["batch_size"],
+        minimal=parameters["minimal"],
+        device=parameters["device"],
+        verbose=parameters["verbose"],
+    )

--- a/cherimoya_cli/commands/negatives.py
+++ b/cherimoya_cli/commands/negatives.py
@@ -2,45 +2,21 @@
 # Author: Jacob Schreiber <jmschreiber91@gmail.com>
 
 
-def add_parser(subparsers):
-	parser = subparsers.add_parser("negatives",
-		help="Sample GC-matched negatives.")
-	parser.add_argument("-i", "--peaks", required=True,
-		help="Peak bed file.")
-	parser.add_argument("-f", "--fasta", help="Genome FASTA file.")
-	parser.add_argument("-b", "--bigwig", help="Optional signal bigwig.")
-	parser.add_argument("-o", "--output", required=True,
-		help="Output bed file.")
-	parser.add_argument("-l", "--bin_width", type=float, default=0.02,
-		help="GC bin width to match.")
-	parser.add_argument("-n", "--max_n_perc", type=float, default=0.1,
-		help="Maximum percentage of Ns allowed in each locus.")
-	parser.add_argument("-a", "--beta", type=float, default=0.5,
-		help="Multiplier on the minimum counts in peaks.")
-	parser.add_argument("-w", "--in_window", type=int, default=2114,
-		help="Width for calculating GC content.")
-	parser.add_argument("-x", "--out_window", type=int, default=1000,
-		help="Non-overlapping stride to use for loci.")
-	parser.add_argument("-v", "--verbose", default=False,
-		action='store_true')
-	return parser
-
-
 def run(args):
-	from tangermeme.match import extract_matching_loci
+    from tangermeme.match import extract_matching_loci
 
-	matched_loci = extract_matching_loci(
-		loci=args.peaks,
-		fasta=args.fasta,
-		gc_bin_width=args.bin_width,
-		max_n_perc=args.max_n_perc,
-		bigwig=args.bigwig,
-		signal_beta=args.beta,
-		in_window=args.in_window,
-		out_window=args.out_window,
-		chroms=None,
-		verbose=args.verbose,
-		n_jobs=1
-	)
+    matched_loci = extract_matching_loci(
+        loci=args.peaks,
+        fasta=args.fasta,
+        gc_bin_width=args.bin_width,
+        max_n_perc=args.max_n_perc,
+        bigwig=args.bigwig,
+        signal_beta=args.beta,
+        in_window=args.in_window,
+        out_window=args.out_window,
+        chroms=None,
+        verbose=args.verbose,
+        n_jobs=1,
+    )
 
-	matched_loci.to_csv(args.output, header=False, sep='\t', index=False)
+    matched_loci.to_csv(args.output, header=False, sep="\t", index=False)

--- a/cherimoya_cli/commands/pipeline.py
+++ b/cherimoya_cli/commands/pipeline.py
@@ -2,453 +2,478 @@
 # Author: Jacob Schreiber <jmschreiber91@gmail.com>
 
 
-def add_parser(subparsers):
-	parser = subparsers.add_parser("pipeline",
-		help="Run each step on the given files.")
-	parser.add_argument("-p", "--parameters", type=str, required=True,
-		help="A JSON file containing the parameters used for each step.")
-	return parser
-
-
 def _validate_inputs(parameters):
-	"""Validate the inputs to the pipeline before any expensive work.
+    """Validate the inputs to the pipeline before any expensive work.
 
-	Checks that local files referenced by the JSON exist. Remote files
-	(http://, https://, gs://, s3://) are skipped because resolving them
-	requires network access. Raises FileNotFoundError listing every
-	missing path so users see all problems at once.
+    Checks that local files referenced by the JSON exist. Remote files
+    (http://, https://, gs://, s3://) are skipped because resolving them
+    requires network access. Raises FileNotFoundError listing every
+    missing path so users see all problems at once.
 
-	The recursive ``_check`` walks lists, so it correctly handles the
-	grouped ``signals``/``controls`` form (``list`` of ``str`` or
-	``list`` of ``list[str]``).
-	"""
+    The recursive ``_check`` walks lists, so it correctly handles the
+    grouped ``signals``/``controls`` form (``list`` of ``str`` or
+    ``list`` of ``list[str]``).
+    """
 
-	import os
+    import os
 
-	def _is_local(path):
-		return not path.startswith(("http://", "https://", "gs://", "s3://"))
+    def _is_local(path):
+        return not path.startswith(("http://", "https://", "gs://", "s3://"))
 
-	missing = []
+    missing = []
 
-	def _check(path, label):
-		if path is None:
-			return
-		if isinstance(path, (list, tuple)):
-			for p in path:
-				_check(p, label)
-			return
-		if _is_local(path) and not os.path.exists(path):
-			missing.append("{}: {}".format(label, path))
+    def _check(path, label):
+        if path is None:
+            return
+        if isinstance(path, (list, tuple)):
+            for p in path:
+                _check(p, label)
+            return
+        if _is_local(path) and not os.path.exists(path):
+            missing.append("{}: {}".format(label, path))
 
-	_check(parameters.get('sequences'), 'sequences')
-	_check(parameters.get('loci'), 'loci')
-	_check(parameters.get('negatives'), 'negatives')
-	_check(parameters.get('signals'), 'signals')
-	_check(parameters.get('controls'), 'controls')
-	_check(parameters.get('motifs'), 'motifs')
-	_check(parameters.get('exclusion_lists'), 'exclusion_lists')
+    _check(parameters.get("sequences"), "sequences")
+    _check(parameters.get("loci"), "loci")
+    _check(parameters.get("negatives"), "negatives")
+    _check(parameters.get("signals"), "signals")
+    _check(parameters.get("controls"), "controls")
+    _check(parameters.get("motifs"), "motifs")
+    _check(parameters.get("exclusion_lists"), "exclusion_lists")
 
-	if missing:
-		raise FileNotFoundError(
-			"Pipeline cannot start; the following inputs are missing:\n  - "
-			+ "\n  - ".join(missing)
-		)
+    if missing:
+        raise FileNotFoundError(
+            "Pipeline cannot start; the following inputs are missing:\n  - "
+            + "\n  - ".join(missing)
+        )
 
 
 def run(args):
-	import argparse
-	import json
-	import os
-	import subprocess
-	import sys
-
-	import pandas
-
-	from cherimoya.io import normalize_signal_groups
-
-	from . import attribute as attribute_cmd
-	from . import fit as fit_cmd
-	from . import marginalize as marginalize_cmd
-	from . import negatives as negatives_cmd
-	from . import seqlets as seqlets_cmd
-	from ..defaults import (
-		default_fit_parameters,
-		default_attribute_parameters,
-		default_seqlet_parameters,
-		default_annotation_parameters,
-		default_marginalize_parameters,
-		default_pipeline_parameters,
-	)
-	from ..utils import _extract_set, _check_set, merge_parameters
-
-	parameters = merge_parameters(args.parameters, default_pipeline_parameters)
-	preprocess_parameters = merge_parameters(
-		parameters['preprocessing_parameters'],
-		default_pipeline_parameters['preprocessing_parameters']
-	)
-
-	_validate_inputs(parameters)
-
-	pname = parameters['name']
-
-	# Flatten any grouped signals/controls early — every preprocessing
-	# step (MACS3 callpeak, bam2bw, file-extension sniffing) operates on
-	# the underlying files regardless of how they're grouped for the
-	# model. The downstream fit step receives the *original* grouped
-	# form via the pipeline JSON, so grouping is preserved end-to-end.
-	signal_files, signal_groups = normalize_signal_groups(parameters['signals'])
-	control_files, control_groups = normalize_signal_groups(parameters['controls'])
-
-	def _run_step(cmd_fn, json_path):
-		"""Invoke a CLI step in-process by calling its run(args) directly."""
-		if not parameters['dry_run']:
-			cmd_fn(argparse.Namespace(parameters=json_path))
-
-	###
-	# Step 0.1: Run MACS3 to call peaks if not provided
-	###
-
-	if parameters['loci'] is None:
-		if preprocess_parameters['verbose']:
-			print("\nStep 0.1: Call peaks using MACS3.")
-
-		if preprocess_parameters['callpeaks_format'] is None:
-			if preprocess_parameters['fragments']:
-				file_format = 'FRAG'
-			else:
-				fname = signal_files[0]
-
-				if fname.endswith('.gz'):
-					file_format = fname.split(".")[-2].upper()
-				else:
-					file_format = fname.split(".")[-1].upper()
-
-				if preprocess_parameters['paired_end']:
-					file_format += 'PE'
-
-			preprocess_parameters['callpeaks_format'] = file_format
-
-
-		cmd_args = [
-			"macs3", "callpeak",
-			"-f", preprocess_parameters['callpeaks_format'],
-			"-g", str(preprocess_parameters['callpeaks_gsize']),
-			"-n", pname,
-			"-q", str(preprocess_parameters['callpeaks_q']),
-			"-t"
-		]
-
-		cmd_args.extend(signal_files)
-
-		if control_files is not None:
-			cmd_args += ['-c']
-			cmd_args.extend(control_files)
-
-		if preprocess_parameters['fragments']:
-			cmd_args += ['--max-count', '1']
-
-		parameters['loci'] = [pname + '_peaks.narrowPeak']
-
-		if not parameters['dry_run']:
-			subprocess.run(cmd_args, check=True)
-
-
-	###
-	# Step 0.2: Convert from SAM/BAMs to bigwigs if provided
-	###
-
-	ftypes = '.sam', '.bam', '.bed', '.bed.gz', '.tsv', '.tsv.gz'
-
-	if signal_files[0].endswith(ftypes):
-		if preprocess_parameters['verbose']:
-			print("Step 0.2: Convert data to bigWigs")
-
-		cmd_args = [
-			"bam2bw",
-			"-s", parameters['sequences'],
-			"-n", pname,
-			"-ps", str(preprocess_parameters['pos_shift']),
-			"-ns", str(preprocess_parameters['neg_shift']),
-			"-sf", str(preprocess_parameters['scale_factor']),
-			"-p", "-1",
-		]
-
-		if preprocess_parameters['read_depth']:
-			cmd_args += ["-r"]
-
-		if preprocess_parameters["unstranded"]:
-			cmd_args += ["-u"]
-
-		if preprocess_parameters['fragments']:
-			cmd_args += ["-f"]
-
-		if preprocess_parameters["verbose"]:
-			cmd_args += ["-v"]
-
-		cmd_args += signal_files
-		if not parameters['dry_run']:
-			subprocess.run(cmd_args, check=True)
-
-		# After conversion, rewrite `signals` in the grouped form so the
-		# downstream fit JSON declares strandedness correctly. Unstranded
-		# bam2bw produces one bigWig — one unstranded group. Stranded
-		# bam2bw produces a (+, -) pair which must be wrapped in an
-		# inner list to land as a single stranded group.
-		if preprocess_parameters["unstranded"]:
-			parameters['signals'] = [pname + ".bw"]
-		else:
-			parameters['signals'] = [[pname + ".+.bw", pname + ".-.bw"]]
-
-
-	if control_files is not None:
-		if control_files[0].endswith(ftypes):
-			cmd_args = [
-				"bam2bw",
-				"-s", parameters['sequences'],
-				"-n", pname + ".control",
-				"-ps", str(preprocess_parameters['pos_shift']),
-				"-ns", str(preprocess_parameters['neg_shift']),
-				"-p", "-1"
-			]
-
-			if preprocess_parameters['read_depth']:
-				cmd_args += ["-r"]
-
-			if preprocess_parameters["unstranded"]:
-				cmd_args += ["-u"]
-
-			if preprocess_parameters["fragments"]:
-				cmd_args += ["-f"]
-
-			if preprocess_parameters["verbose"]:
-				cmd_args += ["-v"]
-
-			cmd_args += control_files
-			if not parameters['dry_run']:
-				subprocess.run(cmd_args, check=True)
-
-			if preprocess_parameters["unstranded"]:
-				parameters['controls'] = [pname + ".control.bw"]
-			else:
-				parameters['controls'] = [
-					[pname + ".control.+.bw", pname + ".control.-.bw"]]
-
-
-	###
-	# Step 0.3: Identify GC-matched negative regions
-	###
-
-	if parameters['negatives'] is None:
-		if preprocess_parameters['verbose']:
-			print("\nStep 0.3: Find GC-matched negative regions.")
-
-		negatives_args = argparse.Namespace(
-			peaks=parameters["loci"][0],
-			fasta=parameters["sequences"],
-			bigwig=None,
-			output=pname + ".negatives.bed",
-			bin_width=0.02,
-			max_n_perc=0.1,
-			beta=0.5,
-			in_window=parameters['in_window'],
-			out_window=parameters['out_window'],
-			verbose=preprocess_parameters['verbose'],
-		)
-
-		parameters["negatives"] = [pname + ".negatives.bed"]
-
-		if not parameters['dry_run']:
-			negatives_cmd.run(negatives_args)
-
-
-	###
-	# Step 1: Fit a Cherimoya model to the provided data
-	###
-
-	if parameters['verbose']:
-		print("\nStep 1: Fitting a Cherimoya model")
-
-	fit_parameters = _extract_set(parameters, default_fit_parameters,
-		'fit_parameters')
-
-	if parameters.get('model', None) == None:
-		name = pname + '.fit.json'
-		parameters['model'] = pname + '.torch'
-		_check_set(fit_parameters, 'performance_filename', pname + '.performance.tsv')
-
-		with open(name, 'w') as outfile:
-			outfile.write(json.dumps(fit_parameters, sort_keys=True, indent=4))
-
-		_run_step(fit_cmd.run, name)
-
-
-	###
-	# Step 2: Calculate attributions
-	###
-
-	if parameters['verbose']:
-		print("\nStep 2: Calculating attributions")
-
-	attribute_parameters = _extract_set(parameters,
-		default_attribute_parameters, 'attribute_parameters')
-	_check_set(attribute_parameters, 'ohe_filename',  pname+'.attributions.ohe.npz')
-	_check_set(attribute_parameters, 'attr_filename', pname+'.attributions.attr.npz')
-	_check_set(attribute_parameters, 'idx_filename',  pname+'.attributions.idxs.npy')
-
-	name = '{}.attribute.json'.format(parameters['name'])
-	with open(name, 'w') as outfile:
-		outfile.write(json.dumps(attribute_parameters, sort_keys=True, indent=4))
-
-	_run_step(attribute_cmd.run, name)
-
-
-	###
-	# Step 3.1: Identify seqlets from attributions
-	###
-
-	if parameters['verbose']:
-		print("\nStep 3.1: Seqlet identification")
-
-	seqlet_parameters = _extract_set(parameters,
-		default_seqlet_parameters, 'seqlet_parameters')
-	_check_set(seqlet_parameters, "ohe_filename",  pname+'.attributions.ohe.npz')
-	_check_set(seqlet_parameters, "attr_filename", pname+'.attributions.attr.npz')
-	_check_set(seqlet_parameters, "idx_filename",  pname+'.attributions.idxs.npy')
-	_check_set(seqlet_parameters, "output_filename", pname+".seqlets.bed")
-	_check_set(seqlet_parameters, "chroms", attribute_parameters['chroms'])
-
-	name = '{}.seqlets.json'.format(parameters['name'])
-	with open(name, 'w') as outfile:
-		outfile.write(json.dumps(seqlet_parameters, sort_keys=True, indent=4))
-
-	_run_step(seqlets_cmd.run, name)
-
-
-	###
-	# Step 3.2: Annotate seqlets using motif database
-	###
-
-	annotation_parameters = _extract_set(parameters,
-		default_annotation_parameters, "annotation_parameters")
-	_check_set(annotation_parameters, "seqlet_filename", pname+".seqlets.bed")
-	_check_set(annotation_parameters, "output_filename", pname+".seqlets_annotated.bed")
-	_check_set(annotation_parameters, "motifs", parameters["motifs"])
-
-	annotation_parameters = merge_parameters(annotation_parameters,
-		default_annotation_parameters)
-
-	if annotation_parameters['motifs'] is not None:
-		if parameters['verbose']:
-			print("\nStep 3.2: Seqlet annotation")
-
-		cmd = ["ttl"]
-		cmd += ["-f", annotation_parameters["sequences"]]
-		cmd += ["-b", annotation_parameters["seqlet_filename"]]
-		cmd += ["-s", str(annotation_parameters["n_score_bins"])]
-		cmd += ["-m", str(annotation_parameters["n_median_bins"])]
-		cmd += ["-a", str(annotation_parameters["n_target_bins"])]
-		cmd += ["-c", str(annotation_parameters["n_cache"])]
-		cmd += ["-j", str(annotation_parameters["n_jobs"])]
-
-		if not annotation_parameters["reverse_complement"]:
-			cmd += ["-r"]
-
-		if annotation_parameters['motifs'] is not None:
-			cmd += ["-t", annotation_parameters["motifs"]]
-
-		if not parameters['dry_run']:
-			with open(annotation_parameters['output_filename'], "w") as f:
-				subprocess.run(cmd, check=True, stdout=f)
-
-		annotated_seqlets = pandas.read_csv(annotation_parameters['output_filename'],
-			sep="\t", header=None, usecols=(3,), names=['motifs'])
-
-		seqlet_count = annotated_seqlets.value_counts()
-		seqlet_count.to_csv(pname+".motif_seqlet_count.tsv", sep="\t")
-
-
-	###
-	# Step 4.1: Run TF-MoDISco
-	###
-
-	if parameters['verbose']:
-		print("\nStep 4.1: TF-MoDISco motifs")
-
-	modisco_parameters = parameters['modisco_motifs_parameters']
-
-	_check_set(modisco_parameters, "output_filename",
-		pname+'_modisco_results.h5')
-	_check_set(modisco_parameters, "verbose",
-		parameters['verbose'])
-
-	modisco_parameters = merge_parameters(modisco_parameters,
-		default_pipeline_parameters['modisco_motifs_parameters'])
-
-	cmd = "modisco motifs -s {} -a {} -n {} -o {}".format(
-		attribute_parameters['ohe_filename'],
-		attribute_parameters['attr_filename'],
-		modisco_parameters['n_seqlets'],
-		modisco_parameters['output_filename'])
-
-	if 'verbose' in modisco_parameters and modisco_parameters['verbose']:
-		cmd += ' -v'
-	elif parameters['verbose']:
-		cmd += ' -v'
-
-	if not parameters['dry_run']:
-		subprocess.run(cmd.split(), check=True)
-
-
-	###
-	# Step 4.2: Generate the tf-modisco report
-	###
-
-	report_parameters = parameters['modisco_report_parameters']
-	_check_set(report_parameters, "verbose", parameters["verbose"])
-	_check_set(report_parameters, "output_folder", pname+"_modisco/")
-	_check_set(report_parameters, "motifs", parameters['motifs'])
-
-	if report_parameters['verbose']:
-		print("\nStep 4.2: TF-MoDISco reports")
-
-	if not parameters['dry_run']:
-		if report_parameters['motifs'] is not None:
-			subprocess.run(["modisco", "report",
-				"-i", modisco_parameters['output_filename'],
-				"-o", report_parameters['output_folder'],
-				"-s", './',
-				"-m", report_parameters['motifs']
-				], check=True)
-		else:
-			subprocess.run(["modisco", "report",
-				"-i", modisco_parameters['output_filename'],
-				"-o", report_parameters['output_folder'],
-				"-s", './'
-				], check=True)
-
-
-	###
-	# Step 5: Marginalization experiments
-	###
-
-	if parameters['motifs'] is None:
-		sys.exit()
-
-	if parameters['verbose']:
-		print("\nStep 5: Run marginalizations")
-
-	marginalize_parameters = _extract_set(parameters,
-		default_marginalize_parameters, "marginalize_parameters")
-
-	_check_set(marginalize_parameters, "loci", parameters["negatives"])
-	_check_set(marginalize_parameters, 'output_filename', pname+"_marginalize/")
-	_check_set(marginalize_parameters, 'motifs', parameters['motifs'])
-	_check_set(marginalize_parameters, 'negatives', parameters['negatives'])
-
-	name = '{}.marginalize.json'.format(parameters['name'])
-
-	with open(name, 'w') as outfile:
-		outfile.write(json.dumps(marginalize_parameters, sort_keys=True,
-			indent=4))
-
-	_run_step(marginalize_cmd.run, name)
+    import argparse
+    import json
+    import os
+    import subprocess
+    import sys
+
+    import pandas
+
+    from cherimoya.io import normalize_signal_groups
+
+    from . import attribute as attribute_cmd
+    from . import fit as fit_cmd
+    from . import marginalize as marginalize_cmd
+    from . import negatives as negatives_cmd
+    from . import seqlets as seqlets_cmd
+    from ..defaults import (
+        default_fit_parameters,
+        default_attribute_parameters,
+        default_seqlet_parameters,
+        default_annotation_parameters,
+        default_marginalize_parameters,
+        default_pipeline_parameters,
+    )
+    from ..utils import _extract_set, _check_set, merge_parameters
+
+    parameters = merge_parameters(args.parameters, default_pipeline_parameters)
+    preprocess_parameters = merge_parameters(
+        parameters["preprocessing_parameters"],
+        default_pipeline_parameters["preprocessing_parameters"],
+    )
+
+    _validate_inputs(parameters)
+
+    pname = parameters["name"]
+
+    # Flatten any grouped signals/controls early — every preprocessing
+    # step (MACS3 callpeak, bam2bw, file-extension sniffing) operates on
+    # the underlying files regardless of how they're grouped for the
+    # model. The downstream fit step receives the *original* grouped
+    # form via the pipeline JSON, so grouping is preserved end-to-end.
+    signal_files, signal_groups = normalize_signal_groups(parameters["signals"])
+    control_files, control_groups = normalize_signal_groups(parameters["controls"])
+
+    def _run_step(cmd_fn, json_path):
+        """Invoke a CLI step in-process by calling its run(args) directly."""
+        if not parameters["dry_run"]:
+            cmd_fn(argparse.Namespace(parameters=json_path))
+
+    ###
+    # Step 0.1: Run MACS3 to call peaks if not provided
+    ###
+
+    if parameters["loci"] is None:
+        if preprocess_parameters["verbose"]:
+            print("\nStep 0.1: Call peaks using MACS3.")
+
+        if preprocess_parameters["callpeaks_format"] is None:
+            if preprocess_parameters["fragments"]:
+                file_format = "FRAG"
+            else:
+                fname = signal_files[0]
+
+                if fname.endswith(".gz"):
+                    file_format = fname.split(".")[-2].upper()
+                else:
+                    file_format = fname.split(".")[-1].upper()
+
+                if preprocess_parameters["paired_end"]:
+                    file_format += "PE"
+
+            preprocess_parameters["callpeaks_format"] = file_format
+
+        cmd_args = [
+            "macs3",
+            "callpeak",
+            "-f",
+            preprocess_parameters["callpeaks_format"],
+            "-g",
+            str(preprocess_parameters["callpeaks_gsize"]),
+            "-n",
+            pname,
+            "-q",
+            str(preprocess_parameters["callpeaks_q"]),
+            "-t",
+        ]
+
+        cmd_args.extend(signal_files)
+
+        if control_files is not None:
+            cmd_args += ["-c"]
+            cmd_args.extend(control_files)
+
+        if preprocess_parameters["fragments"]:
+            cmd_args += ["--max-count", "1"]
+
+        parameters["loci"] = [pname + "_peaks.narrowPeak"]
+
+        if not parameters["dry_run"]:
+            subprocess.run(cmd_args, check=True)
+
+    ###
+    # Step 0.2: Convert from SAM/BAMs to bigwigs if provided
+    ###
+
+    ftypes = ".sam", ".bam", ".bed", ".bed.gz", ".tsv", ".tsv.gz"
+
+    if signal_files[0].endswith(ftypes):
+        if preprocess_parameters["verbose"]:
+            print("Step 0.2: Convert data to bigWigs")
+
+        cmd_args = [
+            "bam2bw",
+            "-s",
+            parameters["sequences"],
+            "-n",
+            pname,
+            "-ps",
+            str(preprocess_parameters["pos_shift"]),
+            "-ns",
+            str(preprocess_parameters["neg_shift"]),
+            "-sf",
+            str(preprocess_parameters["scale_factor"]),
+            "-p",
+            "-1",
+        ]
+
+        if preprocess_parameters["read_depth"]:
+            cmd_args += ["-r"]
+
+        if preprocess_parameters["unstranded"]:
+            cmd_args += ["-u"]
+
+        if preprocess_parameters["fragments"]:
+            cmd_args += ["-f"]
+
+        if preprocess_parameters["verbose"]:
+            cmd_args += ["-v"]
+
+        cmd_args += signal_files
+        if not parameters["dry_run"]:
+            subprocess.run(cmd_args, check=True)
+
+        # After conversion, rewrite `signals` in the grouped form so the
+        # downstream fit JSON declares strandedness correctly. Unstranded
+        # bam2bw produces one bigWig — one unstranded group. Stranded
+        # bam2bw produces a (+, -) pair which must be wrapped in an
+        # inner list to land as a single stranded group.
+        if preprocess_parameters["unstranded"]:
+            parameters["signals"] = [pname + ".bw"]
+        else:
+            parameters["signals"] = [[pname + ".+.bw", pname + ".-.bw"]]
+
+    if control_files is not None:
+        if control_files[0].endswith(ftypes):
+            cmd_args = [
+                "bam2bw",
+                "-s",
+                parameters["sequences"],
+                "-n",
+                pname + ".control",
+                "-ps",
+                str(preprocess_parameters["pos_shift"]),
+                "-ns",
+                str(preprocess_parameters["neg_shift"]),
+                "-p",
+                "-1",
+            ]
+
+            if preprocess_parameters["read_depth"]:
+                cmd_args += ["-r"]
+
+            if preprocess_parameters["unstranded"]:
+                cmd_args += ["-u"]
+
+            if preprocess_parameters["fragments"]:
+                cmd_args += ["-f"]
+
+            if preprocess_parameters["verbose"]:
+                cmd_args += ["-v"]
+
+            cmd_args += control_files
+            if not parameters["dry_run"]:
+                subprocess.run(cmd_args, check=True)
+
+            if preprocess_parameters["unstranded"]:
+                parameters["controls"] = [pname + ".control.bw"]
+            else:
+                parameters["controls"] = [
+                    [pname + ".control.+.bw", pname + ".control.-.bw"]
+                ]
+
+    ###
+    # Step 0.3: Identify GC-matched negative regions
+    ###
+
+    if parameters["negatives"] is None:
+        if preprocess_parameters["verbose"]:
+            print("\nStep 0.3: Find GC-matched negative regions.")
+
+        negatives_args = argparse.Namespace(
+            peaks=parameters["loci"][0],
+            fasta=parameters["sequences"],
+            bigwig=None,
+            output=pname + ".negatives.bed",
+            bin_width=0.02,
+            max_n_perc=0.1,
+            beta=0.5,
+            in_window=parameters["in_window"],
+            out_window=parameters["out_window"],
+            verbose=preprocess_parameters["verbose"],
+        )
+
+        parameters["negatives"] = [pname + ".negatives.bed"]
+
+        if not parameters["dry_run"]:
+            negatives_cmd.run(negatives_args)
+
+    ###
+    # Step 1: Fit a Cherimoya model to the provided data
+    ###
+
+    if parameters["verbose"]:
+        print("\nStep 1: Fitting a Cherimoya model")
+
+    fit_parameters = _extract_set(parameters, default_fit_parameters, "fit_parameters")
+
+    if parameters.get("model", None) == None:
+        name = pname + ".fit.json"
+        parameters["model"] = pname + ".torch"
+        _check_set(fit_parameters, "performance_filename", pname + ".performance.tsv")
+
+        with open(name, "w") as outfile:
+            outfile.write(json.dumps(fit_parameters, sort_keys=True, indent=4))
+
+        _run_step(fit_cmd.run, name)
+
+    ###
+    # Step 2: Calculate attributions
+    ###
+
+    if parameters["verbose"]:
+        print("\nStep 2: Calculating attributions")
+
+    attribute_parameters = _extract_set(
+        parameters, default_attribute_parameters, "attribute_parameters"
+    )
+    _check_set(attribute_parameters, "ohe_filename", pname + ".attributions.ohe.npz")
+    _check_set(attribute_parameters, "attr_filename", pname + ".attributions.attr.npz")
+    _check_set(attribute_parameters, "idx_filename", pname + ".attributions.idxs.npy")
+
+    name = "{}.attribute.json".format(parameters["name"])
+    with open(name, "w") as outfile:
+        outfile.write(json.dumps(attribute_parameters, sort_keys=True, indent=4))
+
+    _run_step(attribute_cmd.run, name)
+
+    ###
+    # Step 3.1: Identify seqlets from attributions
+    ###
+
+    if parameters["verbose"]:
+        print("\nStep 3.1: Seqlet identification")
+
+    seqlet_parameters = _extract_set(
+        parameters, default_seqlet_parameters, "seqlet_parameters"
+    )
+    _check_set(seqlet_parameters, "ohe_filename", pname + ".attributions.ohe.npz")
+    _check_set(seqlet_parameters, "attr_filename", pname + ".attributions.attr.npz")
+    _check_set(seqlet_parameters, "idx_filename", pname + ".attributions.idxs.npy")
+    _check_set(seqlet_parameters, "output_filename", pname + ".seqlets.bed")
+    _check_set(seqlet_parameters, "chroms", attribute_parameters["chroms"])
+
+    name = "{}.seqlets.json".format(parameters["name"])
+    with open(name, "w") as outfile:
+        outfile.write(json.dumps(seqlet_parameters, sort_keys=True, indent=4))
+
+    _run_step(seqlets_cmd.run, name)
+
+    ###
+    # Step 3.2: Annotate seqlets using motif database
+    ###
+
+    annotation_parameters = _extract_set(
+        parameters, default_annotation_parameters, "annotation_parameters"
+    )
+    _check_set(annotation_parameters, "seqlet_filename", pname + ".seqlets.bed")
+    _check_set(
+        annotation_parameters, "output_filename", pname + ".seqlets_annotated.bed"
+    )
+    _check_set(annotation_parameters, "motifs", parameters["motifs"])
+
+    annotation_parameters = merge_parameters(
+        annotation_parameters, default_annotation_parameters
+    )
+
+    if annotation_parameters["motifs"] is not None:
+        if parameters["verbose"]:
+            print("\nStep 3.2: Seqlet annotation")
+
+        cmd = ["ttl"]
+        cmd += ["-f", annotation_parameters["sequences"]]
+        cmd += ["-b", annotation_parameters["seqlet_filename"]]
+        cmd += ["-s", str(annotation_parameters["n_score_bins"])]
+        cmd += ["-m", str(annotation_parameters["n_median_bins"])]
+        cmd += ["-a", str(annotation_parameters["n_target_bins"])]
+        cmd += ["-c", str(annotation_parameters["n_cache"])]
+        cmd += ["-j", str(annotation_parameters["n_jobs"])]
+
+        if not annotation_parameters["reverse_complement"]:
+            cmd += ["-r"]
+
+        if annotation_parameters["motifs"] is not None:
+            cmd += ["-t", annotation_parameters["motifs"]]
+
+        if not parameters["dry_run"]:
+            with open(annotation_parameters["output_filename"], "w") as f:
+                subprocess.run(cmd, check=True, stdout=f)
+
+        annotated_seqlets = pandas.read_csv(
+            annotation_parameters["output_filename"],
+            sep="\t",
+            header=None,
+            usecols=(3,),
+            names=["motifs"],
+        )
+
+        seqlet_count = annotated_seqlets.value_counts()
+        seqlet_count.to_csv(pname + ".motif_seqlet_count.tsv", sep="\t")
+
+    ###
+    # Step 4.1: Run TF-MoDISco
+    ###
+
+    if parameters["verbose"]:
+        print("\nStep 4.1: TF-MoDISco motifs")
+
+    modisco_parameters = parameters["modisco_motifs_parameters"]
+
+    _check_set(modisco_parameters, "output_filename", pname + "_modisco_results.h5")
+    _check_set(modisco_parameters, "verbose", parameters["verbose"])
+
+    modisco_parameters = merge_parameters(
+        modisco_parameters, default_pipeline_parameters["modisco_motifs_parameters"]
+    )
+
+    cmd = "modisco motifs -s {} -a {} -n {} -o {}".format(
+        attribute_parameters["ohe_filename"],
+        attribute_parameters["attr_filename"],
+        modisco_parameters["n_seqlets"],
+        modisco_parameters["output_filename"],
+    )
+
+    if "verbose" in modisco_parameters and modisco_parameters["verbose"]:
+        cmd += " -v"
+    elif parameters["verbose"]:
+        cmd += " -v"
+
+    if not parameters["dry_run"]:
+        subprocess.run(cmd.split(), check=True)
+
+    ###
+    # Step 4.2: Generate the tf-modisco report
+    ###
+
+    report_parameters = parameters["modisco_report_parameters"]
+    _check_set(report_parameters, "verbose", parameters["verbose"])
+    _check_set(report_parameters, "output_folder", pname + "_modisco/")
+    _check_set(report_parameters, "motifs", parameters["motifs"])
+
+    if report_parameters["verbose"]:
+        print("\nStep 4.2: TF-MoDISco reports")
+
+    if not parameters["dry_run"]:
+        if report_parameters["motifs"] is not None:
+            subprocess.run(
+                [
+                    "modisco",
+                    "report",
+                    "-i",
+                    modisco_parameters["output_filename"],
+                    "-o",
+                    report_parameters["output_folder"],
+                    "-s",
+                    "./",
+                    "-m",
+                    report_parameters["motifs"],
+                ],
+                check=True,
+            )
+        else:
+            subprocess.run(
+                [
+                    "modisco",
+                    "report",
+                    "-i",
+                    modisco_parameters["output_filename"],
+                    "-o",
+                    report_parameters["output_folder"],
+                    "-s",
+                    "./",
+                ],
+                check=True,
+            )
+
+    ###
+    # Step 5: Marginalization experiments
+    ###
+
+    if parameters["motifs"] is None:
+        sys.exit()
+
+    if parameters["verbose"]:
+        print("\nStep 5: Run marginalizations")
+
+    marginalize_parameters = _extract_set(
+        parameters, default_marginalize_parameters, "marginalize_parameters"
+    )
+
+    _check_set(marginalize_parameters, "loci", parameters["negatives"])
+    _check_set(marginalize_parameters, "output_filename", pname + "_marginalize/")
+    _check_set(marginalize_parameters, "motifs", parameters["motifs"])
+    _check_set(marginalize_parameters, "negatives", parameters["negatives"])
+
+    name = "{}.marginalize.json".format(parameters["name"])
+
+    with open(name, "w") as outfile:
+        outfile.write(json.dumps(marginalize_parameters, sort_keys=True, indent=4))
+
+    _run_step(marginalize_cmd.run, name)

--- a/cherimoya_cli/commands/pipeline_json.py
+++ b/cherimoya_cli/commands/pipeline_json.py
@@ -2,64 +2,30 @@
 # Author: Jacob Schreiber <jmschreiber91@gmail.com>
 
 
-def add_parser(subparsers):
-	parser = subparsers.add_parser("pipeline-json",
-		help="Make a pipeline JSON file given the provided information.")
-	parser.add_argument("-s", "--sequences", type=str,
-		help="The FASTA file of sequences.")
-	parser.add_argument("-i", "--inputs", type=str, action='append',
-		help="A BAM or bigwig file. Repeatable.")
-	parser.add_argument("-c", "--controls", type=str, action='append',
-		help="A BAM or bigwig file. Repeatable.")
-	parser.add_argument("-p", "--peaks", type=str, action='append',
-		help="A BED-formatted file of peaks to use. Repeatable.")
-	parser.add_argument("-neg", "--negatives", type=str, action='append',
-		help="A BED-formatted file of negative loci to use. Repeatable.")
-	parser.add_argument("-n", "--name", type=str,
-		help="Name to use as a suffix in intermediary files.")
-	parser.add_argument("-u", "--unstranded", action='store_true',
-		default=False, help="Whether the input is stranded")
-	parser.add_argument("-f", "--fragments", action='store_true',
-		default=False, help='Whether the input are fragments or reads.')
-	parser.add_argument("-ps", "--pos_shift", type=int,
-		default=0, help="How many bp to shift the + strand reads.")
-	parser.add_argument("-ns", "--neg_shift", type=int,
-		default=0, help="how many bp to shift the - strand reads.")
-	parser.add_argument("-m", "--motifs", type=str, default=None,
-		help="A motif database for marginalization and TF-MoDISco.")
-	parser.add_argument("-o", "--output", type=str,
-		help="The filename for the pipeline JSON.")
-	parser.add_argument("-pe", "--paired_end", action='store_true',
-		default=False, help="Whether the input is paired-end.")
-	parser.add_argument("-sf", "--scale_factor", default=1,
-		help="Whether to scale the read counts. 1 is no scaling.")
-	return parser
-
-
 def run(args):
-	import sys
-	import json
-	import copy
+    import sys
+    import json
+    import copy
 
-	from ..defaults import default_pipeline_parameters
+    from ..defaults import default_pipeline_parameters
 
-	parameters = copy.deepcopy(default_pipeline_parameters)
+    parameters = copy.deepcopy(default_pipeline_parameters)
 
-	parameters['sequences'] = args.sequences
-	parameters['loci'] = args.peaks
-	parameters['negatives'] = args.negatives
-	parameters['signals'] = args.inputs
-	parameters['controls'] = args.controls
-	parameters['name'] = args.name
-	parameters['motifs'] = args.motifs
-	parameters['preprocessing_parameters']['unstranded'] = args.unstranded
-	parameters['preprocessing_parameters']['fragments'] = args.fragments
-	parameters['preprocessing_parameters']['pos_shift'] = args.pos_shift
-	parameters['preprocessing_parameters']['neg_shift'] = args.neg_shift
-	parameters['preprocessing_parameters']['paired_end'] = args.paired_end
-	parameters['preprocessing_parameters']['scale_factor'] = args.scale_factor
+    parameters["sequences"] = args.sequences
+    parameters["loci"] = args.peaks
+    parameters["negatives"] = args.negatives
+    parameters["signals"] = args.inputs
+    parameters["controls"] = args.controls
+    parameters["name"] = args.name
+    parameters["motifs"] = args.motifs
+    parameters["preprocessing_parameters"]["unstranded"] = args.unstranded
+    parameters["preprocessing_parameters"]["fragments"] = args.fragments
+    parameters["preprocessing_parameters"]["pos_shift"] = args.pos_shift
+    parameters["preprocessing_parameters"]["neg_shift"] = args.neg_shift
+    parameters["preprocessing_parameters"]["paired_end"] = args.paired_end
+    parameters["preprocessing_parameters"]["scale_factor"] = args.scale_factor
 
-	with open(args.output, 'w') as outfile:
-		outfile.write(json.dumps(parameters, indent=4))
+    with open(args.output, "w") as outfile:
+        outfile.write(json.dumps(parameters, indent=4))
 
-	sys.exit()
+    sys.exit()

--- a/cherimoya_cli/commands/seqlets.py
+++ b/cherimoya_cli/commands/seqlets.py
@@ -2,53 +2,44 @@
 # Author: Jacob Schreiber <jmschreiber91@gmail.com>
 
 
-def add_parser(subparsers):
-	parser = subparsers.add_parser("seqlets",
-		help="Identify seqlets from attributions.")
-	parser.add_argument("-p", "--parameters", type=str, required=True,
-		help="A JSON file containing the parameters for identifying seqlets.")
-	return parser
-
-
 def run(args):
-	import sys
+    import sys
 
-	import numpy
-	import torch
+    import numpy
+    import torch
 
-	from tangermeme.io import _interleave_loci
-	from tangermeme.seqlet import recursive_seqlets
-	from tangermeme.utils import example_to_fasta_coords
+    from tangermeme.io import _interleave_loci
+    from tangermeme.seqlet import recursive_seqlets
+    from tangermeme.utils import example_to_fasta_coords
 
-	from ..defaults import default_seqlet_parameters
-	from ..utils import merge_parameters
+    from ..defaults import default_seqlet_parameters
+    from ..utils import merge_parameters
 
-	parameters = merge_parameters(args.parameters, default_seqlet_parameters)
-	if parameters['skip']:
-		sys.exit()
+    parameters = merge_parameters(args.parameters, default_seqlet_parameters)
+    if parameters["skip"]:
+        sys.exit()
 
-	###
+    ###
 
-	idxs = numpy.load(parameters['idx_filename'])
+    idxs = numpy.load(parameters["idx_filename"])
 
-	loci = _interleave_loci(parameters['loci'], parameters['chroms'])
-	loci = loci.iloc[idxs]
+    loci = _interleave_loci(parameters["loci"], parameters["chroms"])
+    loci = loci.iloc[idxs]
 
-	X = numpy.load(parameters['ohe_filename'])['arr_0']
-	X = torch.from_numpy(X)
+    X = numpy.load(parameters["ohe_filename"])["arr_0"]
+    X = torch.from_numpy(X)
 
-	X_attr = numpy.load(parameters['attr_filename'])['arr_0']
-	X_attr = torch.from_numpy(X_attr)
-	X_attr = (X_attr * X).sum(dim=1)
+    X_attr = numpy.load(parameters["attr_filename"])["arr_0"]
+    X_attr = torch.from_numpy(X_attr)
+    X_attr = (X_attr * X).sum(dim=1)
 
-	seqlets = recursive_seqlets(
-		X_attr,
-		threshold=parameters['threshold'],
-		min_seqlet_len=parameters['min_seqlet_len'],
-		max_seqlet_len=parameters['max_seqlet_len'],
-		additional_flanks=parameters['additional_flanks']
-	).sort_values("attribution", ascending=False)
+    seqlets = recursive_seqlets(
+        X_attr,
+        threshold=parameters["threshold"],
+        min_seqlet_len=parameters["min_seqlet_len"],
+        max_seqlet_len=parameters["max_seqlet_len"],
+        additional_flanks=parameters["additional_flanks"],
+    ).sort_values("attribution", ascending=False)
 
-	seqlets = example_to_fasta_coords(seqlets, loci, parameters['in_window'])
-	seqlets.to_csv(parameters['output_filename'], sep='\t', index=False,
-		header=False)
+    seqlets = example_to_fasta_coords(seqlets, loci, parameters["in_window"])
+    seqlets.to_csv(parameters["output_filename"], sep="\t", index=False, header=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,3 +63,8 @@ markers = [
 filterwarnings = [
     "ignore::DeprecationWarning",
 ]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.1.1",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -212,12 +212,13 @@ wheels = [
 
 [[package]]
 name = "cherimoya"
-version = "0.0.1"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "bam2bw" },
     { name = "bpnet-lite" },
     { name = "h5py" },
+    { name = "joblib" },
     { name = "macs3" },
     { name = "modisco" },
     { name = "numpy" },
@@ -240,12 +241,18 @@ docs = [
     { name = "sphinx-copybutton" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "bam2bw", specifier = ">=0.4.1" },
     { name = "bpnet-lite", specifier = ">=1.0.0" },
     { name = "furo", marker = "extra == 'docs'", specifier = ">=2024.1" },
     { name = "h5py", specifier = ">=3.7.0" },
+    { name = "joblib", specifier = ">=1.0.0" },
     { name = "macs3" },
     { name = "modisco", specifier = ">=2.0.0" },
     { name = "numpy", specifier = ">=1.14.2" },
@@ -255,11 +262,14 @@ requires-dist = [
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7.0" },
     { name = "sphinx-copybutton", marker = "extra == 'docs'", specifier = ">=0.5" },
     { name = "tangermeme", specifier = ">=0.2.3" },
-    { name = "torch", specifier = ">=2.6.0" },
+    { name = "torch", specifier = ">=2.9.0" },
     { name = "tqdm", specifier = ">=4.64.1" },
     { name = "triton", specifier = ">=3.5.1" },
 ]
 provides-extras = ["docs"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.1.1" }]
 
 [[package]]
 name = "colorama"
@@ -554,6 +564,18 @@ wheels = [
 ]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.25.2"
 source = { registry = "https://pypi.org/simple" }
@@ -796,6 +818,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/e6/7bf14eeb8f8b7251141944835abd42eb20a658d89084b7e1f3e5fe394090/imagesize-2.0.0.tar.gz", hash = "sha256:8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3", size = 1773045, upload-time = "2026-03-03T14:18:29.941Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl", hash = "sha256:5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96", size = 9441, upload-time = "2026-03-03T14:18:27.892Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -1688,6 +1719,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pybigtools"
 version = "0.2.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1790,6 +1830,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/60/2c8574f13f5a9c07cc14f5b48f70591fcd1ccb50dd59ad9784d48ed31db4/pysam-0.23.3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:b721ae4c9118e0c27e1500be278c3b62022c886eeb913ecabc0463fdf98da38f", size = 27262067, upload-time = "2025-06-10T11:19:29.222Z" },
     { url = "https://files.pythonhosted.org/packages/f3/ef/6ca22f37b3c771f5df38a533d8276dabaacc89a034341a0ec33b7ec21d5e/pysam-0.23.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:915bd2883eed08b16a41964a33923818e67166ca69a51086598d27287df6bb4f", size = 26036767, upload-time = "2025-06-10T11:23:04.839Z" },
     { url = "https://files.pythonhosted.org/packages/99/a4/d52ac0f89fa90ab98998e5c0640963f3f4c1e9703fd4dd0aaa4facaea187/pysam-0.23.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b80f1092ba290b738d6ed230cc58cc75ca815fda441afe76cb4c25639aec7ee7", size = 26477588, upload-time = "2025-06-10T11:19:31.96Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Consolidate all argument parsing into cherimoya_cli/__main__.py and dispatch to the selected subcommand through importlib, so `cherimoya --help` and argument errors no longer import torch and the heavy command modules. Each subcommand module now exposes only run(); the per-command add_parser functions are removed and every subparser gets a distinct variable name. Derive the version from importlib.metadata instead of hardcoding it in cherimoya/__init__.py, and add a dev dependency group pinning pytest.

Note: three regression tests in tests/test_wrappers.py (test_profile_wrapper_regression, test_logcount_wrapper_regression, test_expected_counts_regression) currently fail. They pin exact untrained-model outputs that were generated under a different torch build than the torch 2.11.0 the lockfile pins, so the seeded weight init differs and the values no longer reproduce. Pre-existing and unrelated to these CLI changes.

Some very rudimentary benchmarking with `hyperfine`:

## Baseline (original)

Benchmark 1: uv run cherimoya -h
  Time (mean ± σ):      2.174 s ±  0.174 s    [User: 16.413 s, System: 0.489 s]
  Range (min … max):    2.008 s …  2.606 s    10 runs

## Removed subcommand module imports

Benchmark 1: uv run cherimoya -h
  Time (mean ± σ):      2.781 s ±  0.156 s    [User: 16.879 s, System: 0.587 s]
  Range (min … max):    2.705 s …  3.218 s    10 runs

## Removed cherimoya import

Benchmark 1: uv run cherimoya -h
  Time (mean ± σ):     143.9 ms ±   5.6 ms    [User: 97.4 ms, System: 43.0 ms]
  Range (min … max):   138.5 ms … 162.7 ms    19 runs
