### PR TITLE
ADD Claude Code agent skill and install-skill CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ Any input path can be remote (S3, HTTPS, etc.); the pipeline streams reads throu
 cherimoya pipeline -p pipeline.json
 ```
 
-This calls peaks with MACS3, samples GC-matched negatives, trains a Cherimoya model, computes attributions via saturation mutagenesis, calls seqlets, annotates them with tomtom-lite, and runs TF-MoDISco. The outputs land in the working directory: a `.torch` model checkpoint and training log, per-track bigWigs, a saturation-mutagenesis attribution array (`.npz`), a seqlet table with tomtom-lite annotations, and a TF-MoDISco results H5. Each sub-step writes its own JSON snapshot so individual stages can be re-run in isolation with the `negatives`, `fit`, `evaluate`, `attribute`, `marginalize`, or `seqlets` subcommands. The `batch` subcommand parallelizes a pipeline across multiple datasets. See [the CLI reference](https://cherimoya.readthedocs.io/en/latest/cli.html) for the full command list and JSON schema.
+This calls peaks with MACS3, samples GC-matched negatives, trains a Cherimoya model, computes attributions via saturation mutagenesis, calls seqlets, annotates them with tomtom-lite, and runs TF-MoDISco. The outputs land in the working directory: a `.torch` model checkpoint and training log, per-track bigWigs, a saturation-mutagenesis attribution array (`.npz`), a seqlet table with tomtom-lite annotations, and a TF-MoDISco results H5. Each sub-step writes its own JSON snapshot so individual stages can be re-run in isolation with the `negatives`, `fit`, `evaluate`, `attribute`, `marginalize`, or `seqlets` subcommands. See [the CLI reference](https://cherimoya.readthedocs.io/en/latest/cli.html) for the full command list and JSON schema.
 
 ### Python API and saving/loading
 
-For programmatic use, the three public symbols are `Cherimoya` (the model), `CheriBlock` (the building block), and `EMA` (the parameter exponential-moving-average wrapper used during training). See the [Python API tutorial](https://cherimoya.readthedocs.io/en/latest/tutorials/python_api.html) for an end-to-end training walkthrough:
+For programmatic use, the public API is `Cherimoya` (the model), `CheriBlock` (the building block), `EMA` (the parameter exponential-moving-average wrapper used during training), and four output wrappers — `ControlWrapper`, `ProfileWrapper`, `LogCountWrapper`, and `ExpectedCountsWrapper` — that expose a single tensor from the model's `(profile, log-count)` output for attribution and design tools. See the [Python API tutorial](https://cherimoya.readthedocs.io/en/latest/tutorials/python_api.html) for an end-to-end training walkthrough:
 
 ```python
 from cherimoya import Cherimoya
@@ -120,6 +120,24 @@ model = Cherimoya.load("my_model.torch", device="cuda")
 ```
 
 Older checkpoints saved with `torch.save(model, ...)` are not compatible with `Cherimoya.load` and must be retrained. The CLI subcommands and `model.fit(...)` use this format internally. See [the save/load guide](https://cherimoya.readthedocs.io/en/latest/tutorials/save_load.html) for full semantics (including that the saved weights are the EMA snapshot) and [the Python API reference](https://cherimoya.readthedocs.io/en/latest/api/model.html) for the full `fit()` and `predict()` signatures.
+
+### Claude Code skill
+
+Cherimoya ships an agent skill for [Claude Code](https://claude.com/claude-code) that teaches the assistant to drive the CLI pipeline and Python API on your behalf — working out which inputs you have, choosing assay-appropriate settings, calling the right subcommands, and interpreting the outputs. It uses progressive disclosure: a short router plus topic-specific reference files (training pipeline, input files, assay defaults, interpreting outputs, troubleshooting, CLI reference, Python usage, tangermeme analysis, and a concepts primer) that load only when relevant. The skill is built to ask a clarifying question when an input is ambiguous rather than guess, and to explain in plain language which defaults it applied and why — so it stays useful even if you're new to sequence modeling.
+
+Install it with the bundled subcommand:
+
+```bash
+cherimoya install-skill
+```
+
+This copies the skill into `~/.claude/skills/cherimoya`. Options:
+
+- `-d, --directory DIR` — install into a different skills directory (default `~/.claude/skills`).
+- `--symlink` — symlink the packaged skill instead of copying it, so in-place edits to the installed package are reflected without reinstalling.
+- `-f, --force` — overwrite an existing installation at the destination.
+
+Restart Claude Code (or reload skills) to pick it up, then just describe what you want — for example, *"I have a ChIP-seq BAM and a genome FASTA here, train a Cherimoya model on them"* — and the skill guides the run, asking about anything it needs.
 
 ### Documentation
 

--- a/cherimoya_cli/__main__.py
+++ b/cherimoya_cli/__main__.py
@@ -14,12 +14,13 @@ from .commands import seqlets
 from .commands import marginalize
 from .commands import pipeline
 from .commands import batch
+from .commands import install_skill
 
 
 desc = """A command-line tool for the training and usage of Cherimoya models."""
 
 _help = """Must be either 'negatives', 'fit', 'evaluate',
-	'attribute', 'seqlets', 'marginalize', or 'pipeline'."""
+	'attribute', 'seqlets', 'marginalize', 'pipeline', or 'install-skill'."""
 
 
 def main():
@@ -37,6 +38,7 @@ def main():
 	seqlets.add_parser(subparsers)
 	marginalize.add_parser(subparsers)
 	pipeline.add_parser(subparsers)
+	install_skill.add_parser(subparsers)
 
 	args = parser.parse_args()
 	
@@ -50,6 +52,7 @@ def main():
 		'seqlets': seqlets.run,
 		'marginalize': marginalize.run,
 		'pipeline': pipeline.run,
+		'install-skill': install_skill.run,
 	}
 
 	commands[args.cmd](args)

--- a/cherimoya_cli/commands/install_skill.py
+++ b/cherimoya_cli/commands/install_skill.py
@@ -1,0 +1,58 @@
+# cherimoya_cli install-skill command
+# Author: Jacob Schreiber <jmschreiber91@gmail.com>
+
+
+def add_parser(subparsers):
+	parser = subparsers.add_parser("install-skill",
+		help="Install the bundled Cherimoya agent skill for Claude Code.")
+	parser.add_argument("-d", "--directory", type=str, default=None,
+		help="Skills directory to install into. Default is "
+		"~/.claude/skills.")
+	parser.add_argument("--symlink", action='store_true', default=False,
+		help="Symlink the packaged skill instead of copying it. Reflects "
+		"in-place edits, but breaks if the install location moves.")
+	parser.add_argument("-f", "--force", action='store_true', default=False,
+		help="Overwrite an existing installation at the destination.")
+	return parser
+
+
+def run(args):
+	import os
+	import shutil
+
+	source = os.path.join(os.path.dirname(os.path.dirname(
+		os.path.abspath(__file__))), "skills", "cherimoya")
+
+	if not os.path.isdir(source):
+		raise FileNotFoundError(
+			"Bundled skill not found at {}; the package may be installed "
+			"without its data files.".format(source))
+
+	if args.directory is not None:
+		skills_dir = os.path.expanduser(args.directory)
+	else:
+		skills_dir = os.path.expanduser(os.path.join("~", ".claude", "skills"))
+
+	os.makedirs(skills_dir, exist_ok=True)
+	dest = os.path.join(skills_dir, "cherimoya")
+
+	if os.path.lexists(dest):
+		if not args.force:
+			raise FileExistsError(
+				"A skill already exists at {}. Re-run with --force to "
+				"overwrite it.".format(dest))
+
+		if os.path.islink(dest) or os.path.isfile(dest):
+			os.remove(dest)
+		else:
+			shutil.rmtree(dest)
+
+	if args.symlink:
+		os.symlink(source, dest)
+		print("Symlinked Cherimoya skill:\n  {} -> {}".format(dest, source))
+	else:
+		shutil.copytree(source, dest,
+			ignore=shutil.ignore_patterns(".ipynb_checkpoints"))
+		print("Installed Cherimoya skill to:\n  {}".format(dest))
+
+	print("Restart Claude Code (or reload skills) to pick it up.")

--- a/cherimoya_cli/skills/cherimoya/SKILL.md
+++ b/cherimoya_cli/skills/cherimoya/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: cherimoya
+description: >-
+  Train, evaluate, and use Cherimoya sequence-to-function genomic models
+  with the `cherimoya` command-line tools or Python API. Use when a user 
+  wants to run the end-to-end pipeline, use a trained model to do
+  downstream tasks, or troubleshoot a run. Designed for users who may be 
+  new to Cherimoya or to sequence modeling: ask clarifying questions 
+  whenever an input is ambiguous or missing, pick reasonable defaults, 
+  and explain in plain language what was chosen and why.
+---
+
+# Cherimoya
+
+Cherimoya is a compact deep learning model that predicts genomic profile data —
+transcription-factor binding, chromatin accessibility, transcription initiation —
+directly from DNA sequence. It ships an end-to-end command-line pipeline that takes
+raw sequencing data through peak calling, training, attribution, and motif
+discovery in a couple of commands, and a small Python API for programmatic use.
+
+This skill helps you drive that pipeline for someone who may not know the
+terminology. **Most of the value here is behavioral, not encyclopedic:** be
+robust, ask before guessing, and always explain what a default did.
+
+## How to use this skill
+
+1. Read the three operating rules below — they apply to *every* task.
+2. Figure out what the user actually wants (train? evaluate? interpret results?
+   troubleshoot?) and which inputs they have.
+3. Open only the reference file that matches the task (table at the bottom).
+   Do not preload all of them.
+
+## Three operating rules (always in effect)
+
+### 1. Ask, don't guess — for anything biologically meaningful
+
+A wrong genome build, strandedness, or read-shift produces a model that trains
+without error and is quietly wrong. So before running anything, confirm the
+things that can't be recovered from a filename:
+
+- **What is the assay?** (ATAC-seq, DNase-seq, ChIP-seq, CUT&RUN, PRO-seq, …)
+  This drives stranded-vs-unstranded, fragment-vs-read, and read shifts. See
+  `references/assay-defaults.md`.
+- **What genome build are the reads aligned to?** (hg38, hg19, mm10, …) The
+  FASTA, the peaks, and the default chromosome split must all match it.
+- **Which files does the user actually have**, and what is each one? Never
+  invent a path. See `references/input-files.md`.
+- **What is the goal?** "Is my data any good?" → train + read
+  `performance.tsv`. "What motifs did it learn?" → attributions + seqlets +
+  TF-MoDISco. Map lay language onto subcommands before acting.
+
+When in doubt, ask a short question. One clarifying question is always cheaper
+than a wasted training run.
+
+### 2. Handle missing files by asking, not by inventing
+
+The required inputs for training are a **genome FASTA** and at least one
+**signal file**. Peaks, negatives, controls, and a motif database are optional
+(the pipeline generates or skips them). Before building a pipeline JSON:
+
+- List which required inputs are present and which are missing.
+- If a required input is missing, **ask the user for it** — do not fabricate a
+  path or silently proceed.
+- If an *optional* input is missing, say what the pipeline will do instead
+  (e.g. "no peaks given → MACS3 will call them", "no negatives given →
+  GC-matched negatives will be sampled") so the user can veto it.
+- `cherimoya pipeline` runs a pre-flight check and hard-fails listing every
+  missing local path. Your job is to catch this *earlier* by asking. Note that
+  remote paths (`http://`, `https://`, `s3://`, `gs://`) are skipped by the
+  check and streamed directly.
+- If a JSON key points at a file the pipeline is *supposed to produce later*
+  (e.g. `loci` pointing at a not-yet-called peak file), set that key to `null`
+  and let the pipeline make it — otherwise the pre-flight rejects the run.
+
+### 3. Use reasonable defaults — and explain them
+
+Every default lives in `cherimoya_cli/defaults.py`; quote the real value, never
+a guessed one. Whenever a default or an automatic step kicks in, tell the user
+in one plain sentence what happened and why. Examples:
+
+- "You didn't pass peaks, so MACS3 will call them at q < 0.05 (its default)."
+- "Training will use chr8 and chr20 as held-out validation — the hg38 default.
+  If your data isn't hg38, we need to change this."
+- "The model trains for up to 20 epochs with early stopping after 5 epochs of
+  no improvement in validation count Pearson."
+
+The point is that a novice should never be surprised by something the pipeline
+did on their behalf.
+
+## The common request: "train a model on my data"
+
+The end-to-end flow is two commands (details in
+`references/cli-training-pipeline.md`):
+
+```bash
+# 1. Turn raw-data pointers into a fully-populated JSON config.
+cherimoya pipeline-json -s genome.fa -i signal.bam -m motifs.meme \
+    -n my_run -o my_run.pipeline.json
+
+# 2. Run every step from that JSON.
+cherimoya pipeline -p my_run.pipeline.json
+```
+
+Before running step 1, walk rule 1 and rule 2: confirm the assay, the genome
+build, and which inputs exist. `pipeline-json` fills everything else from
+defaults, and step 2 runs every stage through to marginalization. Some stages
+are conditional — notably, tomtom-lite seqlet annotation and marginalization
+run only when a motif database (`-m`) is given. See
+`references/cli-training-pipeline.md` for the per-step table and what gates each
+step.
+
+## Reference map — open the one that fits the task
+
+| The user wants to… | Read |
+|---|---|
+| Understand a term or how the model works (profile vs counts, seqlets, EMA, …) | `references/concepts.md` |
+| Train / run the full pipeline from raw data | `references/cli-training-pipeline.md` |
+| Know what file types they have / need | `references/input-files.md` |
+| Set assay-specific options (shifts, strandedness) | `references/assay-defaults.md` |
+| Understand what the pipeline produced | `references/interpreting-outputs.md` |
+| Fix an error or a bad-looking result | `references/troubleshooting.md` |
+| Run one subcommand or find a flag | `references/cli.md` |
+| Save / load / run inference with the model in Python | `references/using-in-python.md` |
+| Attribute, ISM, design, score variants | `references/using-tangermeme.md` |
+
+Full project documentation lives at <https://cherimoya.readthedocs.io> (glossary,
+architecture, per-assay recipes, API reference). When a detail isn't in these
+reference files, defer to the docs rather than guessing.

--- a/cherimoya_cli/skills/cherimoya/references/assay-defaults.md
+++ b/cherimoya_cli/skills/cherimoya/references/assay-defaults.md
@@ -1,0 +1,105 @@
+# Assay-specific settings
+
+The assay determines a handful of preprocessing options that change the biology
+of what gets modeled: strandedness, fragments vs reads, paired-end handling, and
+read shifts. None can be inferred from a filename, so **confirm the assay and
+each setting with the user** rather than assuming. The tables below are starting
+points to *propose and confirm*, not values to apply silently.
+
+All map to `pipeline-json` flags and to `preprocessing_parameters` in the JSON.
+
+## The knobs
+
+| Flag | JSON key | Meaning |
+|---|---|---|
+| `-u` | `unstranded` | Produce one unstranded track instead of a `(+, -)` pair. |
+| `-f` | `fragments` | Input is fragment files, not aligned reads. |
+| `-pe` | `paired_end` | Input is paired-end; affects MACS3 format (`BAMPE`). |
+| `-ps N` | `pos_shift` | Shift `+` strand reads by N bp. |
+| `-ns N` | `neg_shift` | Shift `-` strand reads by N bp. |
+| `-sf X` | `scale_factor` | Multiply raw counts by X (default 1 = no scaling). |
+| — | `callpeaks_gsize` | MACS3 effective genome size: `"hs"` human, `"mm"` mouse. |
+| — | `callpeaks_q` | MACS3 q-value cutoff (default 0.05). Loosen to 0.1 for low-yield; tighten to 0.01 for high-confidence. |
+
+Every shift defaults to **0** and strandedness defaults to **stranded**
+(`unstranded=false`), so doing nothing gives a stranded, unshifted, read-based
+run — *wrong* for ATAC and DNase. Hence confirming the assay matters.
+
+## Reads vs. fragments (`-f` and `-pe`)
+
+For ATAC-seq and DNase-seq especially, the biggest thing to get right is whether
+the input holds **aligned reads** or **fragments**; it decides `-f` and `-pe`.
+These are *not* interchangeable and depend only on the file, not the assay:
+
+| Input | Typical file | `-f` | `-pe` |
+|---|---|---|---|
+| **Fragment file** | `.tsv`, `.tsv.gz` (also `.bed`/`.bed.gz`) | **yes** | **no** |
+| **Paired-end reads** | `.bam` (paired-end ATAC) | no | **yes** |
+| **Single-end reads** | `.bam` (typical DNase) | no | no |
+
+Why (from the pipeline source):
+- **`-f` (fragments)** is what routes a fragment file correctly: MACS3 uses
+  `FRAG` format and `bam2bw` parses fragment intervals rather than reads.
+- **`-pe` (paired-end)** exists *only* to switch MACS3 to `BAMPE` for a
+  paired-end **BAM of reads**. A fragment file is already `FRAG`, so **`-pe` has
+  no effect on fragments** — don't add it there.
+
+So: a fragment file gets `-f` and *not* `-pe`; a paired-end read BAM gets `-pe`
+and *not* `-f`. If unsure which a user has, ask — or infer from the extension and
+confirm (see the flag/filetype check in `input-files.md`).
+
+## Starting points by assay (confirm before applying)
+
+### ATAC-seq (unstranded, +4 / −4 Tn5 shift)
+Unstranded, Tn5 insertion conventionally corrected with a **+4 / −4** shift. The
+rest depends on reads vs. fragments:
+
+- **Paired-end read BAM** (`atac.bam`): `-u -ps 4 -ns -4 -pe`
+- **Fragment file** (`atac.fragments.tsv.gz`): `-u -ps 4 -ns -4 -f`
+  (`-f`, not `-pe` — see the table.)
+- **Ask whether the data is already shifted.** Many pipelines (10x/CellRanger/
+  ArchR-derived fragments) pre-apply the Tn5 shift; applying it twice is wrong.
+  If already shifted, drop `-ps`/`-ns` (keep `-u` and the reads/fragments flag) —
+  or, if the upstream shift used the older +4/−5 convention, set the shifts to
+  the relative offset rather than zero.
+
+### DNase-seq (unstranded, usually single-end, no shift)
+Typically a single-end read BAM modeled as one unstranded track: `-u`
+- No `-pe` (single-end), no `-f` (aligned reads, not fragments).
+- No shift by default; some protocols apply a small `+1 / 0` cut-site shift
+  (`-ps 1 -ns 0`) for footprint work — confirm.
+- For a paired-end DNase read BAM, add `-pe`; for a stranded variant, omit `-u`.
+
+### ChIP-seq (TF or histone)
+- **TF ChIP-seq is stranded by default** (`+` and `-` coverage modeled as two
+  tracks), single-end, no shift, **with an input control**:
+  `-i chip.bam -c input.bam`
+  Do **not** pass `-u` — the default (`unstranded: false`) is what you want.
+- `-i` is the ChIP/IP signal; `-c` the unenriched input control. Confirm the
+  user has the matched input — a control-trained model must be used with controls
+  thereafter.
+- If **paired-end**, add `-pe`. Histone ChIP is *sometimes* modeled unstranded
+  (`-u`) — a confirm-with-user choice, not a default.
+
+### Stranded assays (many TF profiling / initiation assays, PRO-seq, CAGE)
+- Leave strandedness on (omit `-u`); the pipeline emits a `(+, -)` pair as one
+  stranded group.
+- For pre-made bigWigs, remember the nested grouping
+  (`[["plus.bw","minus.bw"]]`) from `input-files.md`.
+
+### Non-human genome
+- Set `callpeaks_gsize` to `"mm"` for mouse (or a numeric effective size), **and**
+  replace the hg38 `training_chroms` / `validation_chroms` with names/splits
+  valid for that genome. The chromosome default is the most commonly missed one
+  for non-human data.
+
+## When you're unsure
+
+If the user can't say whether the data is shifted, stranded, or paired-end,
+**ask one question** rather than pick a default — an unnecessary read shift or
+wrong strandedness degrades the model with no error message. A safe fallback for
+a totally-unknown coverage track is unstranded, unshifted (`-u`), which at least
+won't double-apply a correction.
+
+Full recipes with worked commands: the ChIP-seq, ATAC-seq, and DNase-seq pages
+under <https://cherimoya.readthedocs.io/en/latest/> (recipes section).

--- a/cherimoya_cli/skills/cherimoya/references/cli-training-pipeline.md
+++ b/cherimoya_cli/skills/cherimoya/references/cli-training-pipeline.md
@@ -1,0 +1,124 @@
+# Training a model with the CLI pipeline
+
+The end-to-end workflow is two commands: `cherimoya pipeline-json` builds a
+config from a few pointers, and `cherimoya pipeline` runs every step from it.
+This is the path for "train a Cherimoya model on my data."
+
+First complete the checks in `SKILL.md` (assay, genome build, which inputs
+exist). This file assumes that's done.
+
+## Step 1 — build the pipeline JSON
+
+`cherimoya pipeline-json` takes a few CLI pointers and emits a fully-populated
+JSON, filling everything you don't specify from `cherimoya_cli/defaults.py`.
+
+```bash
+cherimoya pipeline-json \
+    -s genome.fa \          # reference genome FASTA (REQUIRED)
+    -i signal.bam \         # signal file; repeat -i for replicates (REQUIRED)
+    -c control.bam \        # optional control; repeat -c for replicates
+    -p peaks.narrowPeak \   # optional BED of peaks (else MACS3 calls them)
+    -neg negatives.bed \    # optional BED of negatives (else sampled)
+    -m motifs.meme \        # optional MEME motif database
+    -n my_run \             # name suffix used in every output filename
+    -o my_run.pipeline.json # where to write the JSON
+```
+
+Assay-specific flags (`-u` unstranded, `-f` fragments, `-pe` paired-end,
+`-ps`/`-ns` read shifts, `-sf` scale factor) are in `assay-defaults.md` — get
+them right, because they change the biology, not just the bookkeeping.
+
+**Watch the `-p` flag.** In `pipeline-json`, `-p` means **peaks**; in every
+other subcommand it means the **parameters JSON**. Don't carry the meaning
+across.
+
+You need `-s` (genome), `-i` (signal), `-n` (name), and `-o` (output JSON);
+`-c`/`-p`/`-neg`/`-m` are optional. `pipeline-json` enforces *none* at parse
+time, so a missing one fails later or silently produces `None_*` filenames —
+stop and ask the user for any of the four that's absent.
+
+## Step 2 — (optional) edit the JSON
+
+The JSON is both the run config and a permanent record. Common novice edits —
+always explain the change you make:
+
+- **Not hg38?** The default `fit_parameters.training_chroms` /
+  `fit_parameters.validation_chroms` are hg38 names. Update them to the user's
+  genome or validation is silently empty. (For mouse, also set
+  `preprocessing_parameters.callpeaks_gsize` to `"mm"`.)
+- **Out of GPU memory?** Lower `fit_parameters.batch_size` (64 → 32/16) or
+  `fit_parameters.n_filters` (128 → 64), or set `fit_parameters.dtype` to
+  `"bfloat16"`.
+- **Small dataset?** See dataset-size guidance in `troubleshooting.md`.
+- **Skip a step:** most sub-dicts accept `"skip": true`.
+- **Dry run:** set top-level `"dry_run": true` to write all per-step JSONs
+  without running anything — useful to show the user what will run before
+  spending GPU time.
+
+Every key and default is tabulated in `cli.md` and, exhaustively, at
+<https://cherimoya.readthedocs.io/en/latest/cli.html>.
+
+## Step 3 — run it
+
+```bash
+cherimoya pipeline -p my_run.pipeline.json
+```
+
+`pipeline` first runs a **pre-flight existence check** on every local input path
+and hard-fails with a list of everything missing before any expensive work.
+Remote paths (`http://`, `https://`, `s3://`, `gs://`) are skipped and streamed.
+If a path it complains about is something the pipeline will create later, set
+that key to `null`.
+
+## What the pipeline does, in order
+
+Each step is driven by a sub-dict of the JSON. The fit, attribute, seqlets, and
+marginalize steps each write a JSON snapshot (`{name}.fit.json`, etc.) so they
+can be re-run in isolation; the preprocessing, annotation, and MoDISco steps run
+inline and write no snapshot.
+
+| Step | Runs when | Produces |
+|---|---|---|
+| 0.1 MACS3 peak calling | `loci` is `null` | `{name}_peaks.narrowPeak` |
+| 0.2 `bam2bw` signal → bigWig | signals aren't already bigWig (`.sam/.bam/.bed[.gz]/.tsv[.gz]`) | `{name}.+.bw`/`{name}.-.bw` (stranded) or `{name}.bw` (unstranded); controls → `{name}.control.*.bw` |
+| 0.3 negative sampling | `negatives` is `null` | `{name}.negatives.bed` |
+| 1 train | always (unless `model` set) | `{name}.torch`, `{name}.final.torch`, `{name}.log`, `{name}.detailed.log`, `{name}.performance.tsv` |
+| 2 attribute | always | `{name}.attributions.{ohe,attr}.npz`, `{name}.attributions.idxs.npy` |
+| 3.1 seqlets | always | `{name}.seqlets.bed` |
+| 3.2 tomtom-lite annotation | `motifs` is set | `{name}.seqlets_annotated.bed`, `{name}.motif_seqlet_count.tsv` |
+| 4.1/4.2 TF-MoDISco | always | `{name}_modisco_results.h5`, `{name}_modisco/` |
+| 5 marginalization | `motifs` is set | `{name}_marginalize/` |
+
+Worth telling a user up front:
+
+- **Pass an existing `model` path in the JSON and training is skipped** — that
+  checkpoint is used for all downstream steps.
+- **TF-MoDISco runs even without a motif database** (it discovers motifs *de
+  novo*); the database only *names* what it found. The motif-gated steps (tomtom
+  annotation, marginalization) are what get skipped without `-m`, so the run
+  ends after TF-MoDISco.
+- `{name}.torch` is the best-validation checkpoint the downstream steps load;
+  see `interpreting-outputs.md` for `.torch` vs `.final.torch`.
+
+## Re-running a single step
+
+For the steps that wrote a JSON (fit, attribute, seqlets, marginalize):
+
+```bash
+cherimoya fit        -p my_run.fit.json
+cherimoya evaluate   -p my_run.evaluate.json
+cherimoya attribute  -p my_run.attribute.json
+cherimoya seqlets    -p my_run.seqlets.json
+cherimoya marginalize -p my_run.marginalize.json
+```
+
+Two things that make re-running work:
+- After step 0.2 the pipeline rewrites `signals`/`controls` in the fit JSON to
+  the produced bigWig paths, so re-running `fit` works off the bigWigs even
+  though the input was a BAM.
+- `fit` automatically runs `evaluate` on completion and emits
+  `my_run.evaluate.json` — there's no separate evaluate step in the pipeline,
+  but you can re-run it standalone above.
+
+`negatives` is a standalone subcommand with its own flags (no JSON); see
+`cli.md`.

--- a/cherimoya_cli/skills/cherimoya/references/cli.md
+++ b/cherimoya_cli/skills/cherimoya/references/cli.md
@@ -1,0 +1,66 @@
+# CLI subcommand map
+
+`cherimoya` has one subcommand per pipeline stage. Most people only need
+`pipeline-json` + `pipeline` (see `cli-training-pipeline.md`); the rest re-run a
+single stage. This maps a goal to a subcommand. For exhaustive flag and
+JSON-key tables, defer to
+<https://cherimoya.readthedocs.io/en/latest/cli.html>.
+
+## Goal → subcommand
+
+| Goal | Subcommand |
+|---|---|
+| Build a pipeline config from raw-data pointers | `pipeline-json` |
+| Run the whole thing end-to-end | `pipeline` |
+| Just train (and auto-evaluate) a model | `fit` |
+| Score an existing model on held-out data | `evaluate` |
+| Compute per-base attributions | `attribute` |
+| Call seqlets from attributions | `seqlets` |
+| Measure a model's response to inserted motifs | `marginalize` |
+| Sample GC-matched negative regions | `negatives` |
+
+## Two flag conventions
+
+- **`pipeline-json` and `negatives` take direct CLI flags** (no JSON).
+- **Every other subcommand is driven by a JSON file passed with `-p,
+  --parameters`.** Missing keys fall back to `cherimoya_cli/defaults.py`.
+- **Short flags are overloaded:** `-p` means `--peaks` in `pipeline-json` but
+  `--parameters` elsewhere, and `-i` means `--inputs` (signal) in `pipeline-json`
+  but `--peaks` in `negatives`. Don't carry a flag's meaning across subcommands.
+
+Most JSON schemas accept `"skip": true` to no-op a step; the pipeline JSON also
+accepts `"dry_run": true` to emit per-step JSONs without running anything.
+
+## `pipeline-json` flags
+
+`-s` sequences (FASTA) · `-i` inputs/signal (repeatable) · `-c` controls
+(repeatable) · `-p` peaks (repeatable) · `-neg` negatives (repeatable) ·
+`-n` name · `-o` output JSON · `-m` motifs (MEME) · `-u` unstranded ·
+`-f` fragments · `-pe` paired-end · `-ps` pos_shift · `-ns` neg_shift ·
+`-sf` scale_factor. `-s`, `-i`, `-n`, `-o` are all effectively required
+(argparse enforces none, but a missing one fails later or yields `None_*`
+filenames).
+
+## `negatives` flags (standalone)
+
+`-i` peaks (required) · `-o` output BED (required) · `-f` fasta ·
+`-b` bigwig (sets a min-counts threshold via `--beta`) · `-l` bin_width
+(0.02) · `-n` max_n_perc (0.1) · `-a` beta (0.5) · `-w` in_window (2114) ·
+`-x` out_window (1000) · `-v` verbose.
+
+## Key defaults (from `defaults.py`)
+
+Quote these; don't guess others — read `defaults.py` or the docs.
+
+- Windows: `in_window` 2114, `out_window` 1000.
+- Model: `n_filters` 128, `n_layers` 9, `expansion` 2.
+- Training: `batch_size` 64, `max_epochs` 20, `early_stopping` 5 (epochs of no
+  validation count-Pearson improvement), `n_warmup_epochs` 2,
+  `negative_ratio` 0.25, `reverse_complement` true, `num_workers` 1.
+- Inference stages: `batch_size` 512.
+- Device/dtype: `cuda` / `float32`.
+- Split (hg38): `validation_chroms` = chr8, chr20; everything else (minus
+  chr1/chr3/chr6 held out of the default list) trains. **Change these for
+  non-hg38 genomes.**
+- Peak calling: `callpeaks_gsize` `"hs"`, `callpeaks_q` 0.05.
+- Seqlets: `threshold` 0.01, lengths 4–25 bp, `additional_flanks` 3.

--- a/cherimoya_cli/skills/cherimoya/references/concepts.md
+++ b/cherimoya_cli/skills/cherimoya/references/concepts.md
@@ -1,0 +1,75 @@
+# Concepts — the vocabulary in one place
+
+A plain-language primer for a user new to sequence modeling. Load this when a
+term below is blocking understanding; for depth, the docs glossary at
+<https://cherimoya.readthedocs.io> is authoritative.
+
+## What the model does
+
+Cherimoya is a **sequence-to-function** model: given a stretch of DNA (one-hot
+encoded, `(batch, 4, length)`), it predicts a genomic assay's coverage over that
+stretch. Training teaches it which sequence patterns drive the measured signal.
+
+## Profile vs. counts (the two output heads)
+
+Every forward returns `(profile, log-count)` — two complementary views of the
+same locus:
+- **Profile** — the *shape* of the signal at base-pair resolution across the
+  output window (default 1000 bp): where within the region the reads pile up.
+- **Counts** — the *total* signal in the window (one number per group), trained
+  against `log(count + 1)`. This is the headline "how much signal is here"
+  prediction; `count_pearson` on held-out data is the usual quality metric.
+
+A model can be good at one and not the other — hence separate metrics.
+
+## Peaks, negatives, controls
+
+- **Peaks (`loci`)** — genomic regions of interest, the **positive** examples
+  (where the assay shows enrichment). Supplied as a BED, or called by MACS3 from
+  the signal.
+- **Negatives** — **background** regions the model also trains on so it learns
+  what *absence* of signal looks like. GC-matched to the peaks; `negative_ratio`
+  (default 0.25) sets how many per peak per epoch.
+- **Controls** — an unenriched track (ChIP input / IgG) that captures
+  background/bias. A model trained *with* controls must be used *with* them
+  thereafter, or the count head sees garbage.
+
+## Strandedness
+
+Some assays distinguish the `+` and `-` DNA strands (a `(+, -)` pair of tracks);
+others don't (one unstranded track). This is a per-assay property, not
+inferable from a filename — see `assay-defaults.md`. Getting it wrong is silent;
+see the grouping footgun in `input-files.md`.
+
+## Attribution, seqlets, motifs
+
+The "what did the model learn" chain, in order:
+- **Attribution** — per-base importance scores: which bases the model relied on
+  for its prediction. Cherimoya computes these by **saturation mutagenesis
+  (ISM)** — mutating each base and measuring the change in prediction.
+- **Seqlets** — short, contiguous high-importance stretches pulled out of the
+  attributions (lengths ~4–25 bp): candidate functional elements.
+- **Motifs** — recurring sequence patterns (e.g. a transcription-factor binding
+  site). **TF-MoDISco** clusters seqlets into *de novo* motifs; a supplied MEME
+  motif database lets those discovered motifs be *named* against known ones.
+- **Marginalization** — a complementary check: insert a known motif into
+  background sequences and measure how much the model's prediction responds — how
+  much it "cares" about that motif.
+
+## Training vocabulary
+
+- **Held-out (validation) chromosomes** — whole chromosomes kept out of training
+  (default hg38 split: chr8, chr20) so metrics measure generalization to unseen
+  sequence, not memorization. Must match your genome build.
+- **EMA (exponential moving average)** — a smoothed running average of the model
+  weights kept during training; it validates better than the raw weights.
+  Cherimoya **saves the EMA weights**, so a reloaded model reproduces the EMA
+  validation numbers in the log, not the mid-epoch training loss (see
+  `interpreting-outputs.md`).
+- **Reverse-complement augmentation** — training also shows the model each
+  sequence's reverse complement (on by default); for stranded data this swaps the
+  `+`/`-` tracks, which is why stranded pairs must be grouped correctly.
+- **Early stopping** — training halts after a set number of epochs (default 5)
+  with no improvement in validation count Pearson, keeping the best checkpoint.
+
+For every default value, see `cli.md` or `cherimoya_cli/defaults.py`.

--- a/cherimoya_cli/skills/cherimoya/references/input-files.md
+++ b/cherimoya_cli/skills/cherimoya/references/input-files.md
@@ -1,0 +1,113 @@
+# Identifying the user's input files
+
+Before building a pipeline you need to know *what the user actually has*. This
+is a recognition guide: given a file (often just an extension), what is it, which
+pipeline slot does it fill, and what to confirm. For assay-driven settings
+(shifts, strandedness), see `assay-defaults.md`.
+
+## The pipeline slots
+
+A training run has, at most, these inputs:
+
+| Slot | Flag (`pipeline-json`) | JSON key | Required? |
+|---|---|---|---|
+| Reference genome | `-s` | `sequences` | **Yes** |
+| Signal | `-i` (repeatable) | `signals` | **Yes** |
+| Control | `-c` (repeatable) | `controls` | No |
+| Peaks | `-p` (repeatable) | `loci` | No — else MACS3 calls them |
+| Negatives | `-neg` (repeatable) | `negatives` | No — else sampled |
+| Motif database | `-m` | `motifs` | No — enables annotation + marginalization |
+| Exclusion list | *(none; JSON only)* | `exclusion_lists` | No — BED of regions to drop from train/validation |
+
+If a required slot is empty, ask the user for it. For each empty optional slot,
+tell the user what the pipeline will do instead. `exclusion_lists` has no flag —
+set it directly in the JSON to mask regions (e.g. ENCODE blacklist).
+
+## Recognizing file types
+
+### Reference genome — `sequences`
+- **`.fa`, `.fasta`, `.fa.gz`** — the genome the reads were aligned to.
+- Must match the **genome build** of the signal and peaks (hg38 ≠ hg19 ≠ mm10).
+  The single most important thing to confirm; a mismatch trains a
+  silently-wrong model.
+- Chromosome names in the FASTA must match `training_chroms` /
+  `validation_chroms` in the JSON (e.g. `chr8` vs `8`).
+
+### Signal — `signals`
+The measured coverage the model learns to predict. Two forms:
+- **Aligned reads / fragments: `.bam`, `.sam`, `.bed`, `.bed.gz`, `.tsv`,
+  `.tsv.gz`** — converted to bigWig by `bam2bw` (step 0.2). Fragment files
+  (10x-style) need the `-f`/`fragments` flag.
+- **Coverage tracks: `.bw`, `.bigwig`** — already processed; used directly,
+  conversion skipped.
+
+Confirm with the user:
+- **Reads or fragments?** A `.bam` almost always holds **aligned reads**; a
+  `.tsv`/`.tsv.gz` (often `.bed`/`.bed.gz`) usually holds **fragments**. Decides
+  `-f` and `-pe` — see the reads-vs-fragments table in `assay-defaults.md`.
+- **Stranded or unstranded?** ChIP/ATAC/DNase are usually unstranded (one
+  track); many TF/initiation assays are stranded (`+`/`-` pair). Decides `-u`
+  and the grouping (below). See `assay-defaults.md`.
+- **Replicates?** How they combine depends on input type. **BAM/SAM/fragment**
+  replicates passed as multiple `-i` are merged into one bigWig by `bam2bw` (one
+  pooled track). **Pre-made bigWig** replicates are *not* pooled — a flat list is
+  read as N independent unstranded groups (see the grouping footgun below), so
+  pool them upstream first. (Peak calling pools all replicates as MACS3
+  treatments in both cases.)
+
+> **Check flags against the filetype.** A mismatch is silent:
+> - `-f` (fragments) with a `.bam` of aligned reads, or a fragment `.tsv`
+>   *without* `-f`, misparses the input.
+> - `-pe` only does something for a paired-end read BAM (sets MACS3's `BAMPE`);
+>   it is **ignored for fragment files**, so `-f` with `-pe` is a contradiction —
+>   the intent was `-f` alone.
+> If flags and filetype disagree, stop and ask which is correct.
+
+### Control — `controls`
+- Same file types as signal. For ChIP-seq this is the **input / IgG control**
+  (unenriched DNA). A model trained *with* controls must be evaluated and used
+  *with* the same controls, or the count head sees garbage.
+
+### Peaks — `loci`
+- **`.narrowPeak`, `.bed`, `.broadPeak`** — genomic regions of interest
+  (positives). If absent, MACS3 calls them from the signal at q < 0.05.
+- `summits` in `fit_parameters` centers loci on the narrowPeak summit column.
+  Requires a true narrowPeak (10-column) file — don't set `summits` with a
+  `.broadPeak` or plain `.bed`, which have no summit column.
+
+### Negatives — `negatives`
+- **`.bed`** — background regions the model also trains on. If absent, the
+  pipeline samples GC-matched negatives (step 0.3). `negative_ratio` (default
+  0.25) sets negatives per peak per epoch.
+
+### Motif database — `motifs`
+- **`.meme`** — MEME-format known motifs (e.g. JASPAR, HOCOMOCO). Optional;
+  passing it enables tomtom-lite seqlet annotation and marginalization and lets
+  the TF-MoDISco report *name* discovered motifs. Without it, TF-MoDISco still
+  discovers motifs *de novo* but leaves them unnamed.
+
+## The stranded-signal footgun (important)
+
+`signals` (and `controls`) accept a flat or nested list, and the shape changes
+the meaning:
+
+- **Flat list** → each entry is its own **independent unstranded** track:
+  `["a.bw", "b.bw"]` = two separate unstranded outputs.
+- **Nested list** → the inner list is one **multi-channel group**, e.g. a
+  stranded `(+, -)` pair: `[["ctcf.+.bw", "ctcf.-.bw"]]` = one stranded group.
+
+Getting this wrong is silent: a stranded pair written flat as
+`["plus.bw", "minus.bw"]` becomes two unstranded tracks and disables the `+/-`
+swap during reverse-complement augmentation. Wrap stranded pairs:
+`[["plus.bw", "minus.bw"]]`.
+
+When the pipeline converts BAMs itself (step 0.2) it writes the grouped form for
+you; you assemble it by hand only for pre-made bigWigs. Full semantics: the
+header comment in `cherimoya_cli/defaults.py`.
+
+## Remote files
+
+Any path can be a remote URL (`http://`, `https://`, `s3://`, `gs://`); the
+pipeline streams it via `bam2bw` / `tangermeme.io` without downloading, and the
+pre-flight check skips it. Credentialed buckets need the usual environment
+variables (`AWS_*`, `GOOGLE_APPLICATION_CREDENTIALS`) set first.

--- a/cherimoya_cli/skills/cherimoya/references/interpreting-outputs.md
+++ b/cherimoya_cli/skills/cherimoya/references/interpreting-outputs.md
@@ -1,0 +1,90 @@
+# Reading what the pipeline produced
+
+Maps every output file to a plain-language answer to "did it work?", "is the
+model good?", and "what did it learn?" `{name}` is the `-n` value from step 1.
+
+## "Did it work / is it any good?" — the model and its metrics
+
+### `{name}.performance.tsv` — the scorecard
+One row per signal group, seven columns: `profile_mnll`, `profile_jsd`,
+`profile_pearson`, `profile_spearman`, `count_pearson`, `count_spearman`,
+`count_mse`. Computed on the **held-out validation chromosomes** (default chr8,
+chr20).
+
+Headline number: **`count_pearson`** — how well predicted per-peak total signal
+correlates with truth on held-out chromosomes.
+- Good models on a solid dataset land well above 0.5, often 0.7–0.9+.
+- Near 0 means it didn't learn — see "stuck Pearson" in `troubleshooting.md`
+  (common causes: validation chromosomes with no peaks, dropped controls, an
+  uninformative signal).
+
+`profile_pearson` / `profile_jsd` describe how well the profile **shape**
+(base-pair resolution) was learned, separate from total counts.
+
+### `{name}.log` — per-epoch training curve
+One row per epoch (train/validation metrics). Shows whether validation count
+Pearson climbed and where early stopping kicked in. **Compare final results
+against the EMA validation numbers here, not the mid-epoch training loss** (see
+the checkpoint note below).
+
+### `{name}.detailed.log`
+`.log` plus per-group `ProfilePearson_g{i}` / `CountPearson_g{i}` columns —
+only relevant for multi-group (multi-task) models.
+
+### `{name}.torch` vs `{name}.final.torch` — which checkpoint to use
+Both are **EMA-applied** snapshots (an exponential moving average of the
+weights, which validates better than the raw training weights):
+- **`{name}.torch`** — the **best validation count Pearson** epoch. Downstream
+  steps load this; use it for analysis. Load with `Cherimoya.load`.
+- **`{name}.final.torch`** — the EMA snapshot at the **final** epoch; interesting
+  only if you want the end-of-training state. Because these are EMA weights, a
+  reloaded model reproduces the *EMA* validation row in the log, not any
+  mid-epoch loss — expected, not a bug.
+
+## Intermediate data files
+
+| File | What it is |
+|---|---|
+| `{name}_peaks.narrowPeak` | Peaks MACS3 called (when you didn't supply peaks). |
+| `{name}.negatives.bed` | GC-matched background regions (when you didn't supply negatives). |
+| `{name}.+.bw` / `{name}.-.bw` / `{name}.bw` | bigWig coverage `bam2bw` made (stranded pair / unstranded). |
+| `{name}.control.*.bw` | Same, for controls. |
+
+## "What did the model learn?" — interpretation outputs
+
+### Attributions — `{name}.attributions.*`
+Per-base importance from saturation mutagenesis, over the central 400 bp of each
+locus, as three aligned files:
+- `{name}.attributions.ohe.npz` — one-hot input sequences (that 400 bp span).
+- `{name}.attributions.attr.npz` — hypothetical importance scores.
+- `{name}.attributions.idxs.npy` — boolean mask back to the original loci list
+  (which loci survived N-filtering).
+
+Don't eyeball these as files; load and plot them (see `using-tangermeme.md`) or
+let the seqlet/MoDISco steps consume them.
+
+### Seqlets — `{name}.seqlets.bed`
+Short, high-importance stretches pulled from the attributions, in genome
+coordinates — the candidate functional elements the model found.
+
+### Annotated seqlets — `{name}.seqlets_annotated.bed` + `{name}.motif_seqlet_count.tsv`
+Only with a motif database. tomtom-lite labels each seqlet with its closest
+known motif; the `.tsv` tallies matches per motif — a quick "which TFs did the
+model rely on" summary.
+
+### TF-MoDISco — `{name}_modisco_results.h5` + `{name}_modisco/`
+*De novo* motifs aggregated across all seqlets. The `.h5` holds the patterns;
+`{name}_modisco/` is a browsable **HTML report** (open `index.html`) — usually
+the most satisfying thing to show a user, with names when a motif database was
+supplied.
+
+### Marginalization — `{name}_marginalize/`
+Only with a motif database. Inserts each known motif into background sequences
+and measures the model's predicted response — an HTML-plus-CSV report of how
+much the model "cares" about each motif.
+
+## Per-step JSON snapshots
+
+`{name}.{pipeline,fit,evaluate,attribute,seqlets,marginalize}.json` record the
+exact parameters each step ran with — the record of what happened, and they let
+you re-run any single step (`cherimoya <step> -p {name}.<step>.json`).

--- a/cherimoya_cli/skills/cherimoya/references/troubleshooting.md
+++ b/cherimoya_cli/skills/cherimoya/references/troubleshooting.md
@@ -1,0 +1,112 @@
+# Troubleshooting a Cherimoya run
+
+Common failures, the symptom each produces, and what to change. Match the
+symptom here first. Authoritative version:
+<https://cherimoya.readthedocs.io/en/latest/troubleshooting.html>.
+
+## Prerequisites (check first)
+
+- **GPU.** Training and high-throughput inference want a CUDA GPU. A pure-PyTorch
+  CPU fallback exists for everything except the inference megakernel, so the
+  package runs on CPU, but **training on CPU is impractical at any realistic
+  scale** — warn the user before starting. CPU is fine for interactive use.
+- **Triton** is a hard dependency and installs from PyPI automatically on
+  standard Linux + CUDA. Unusual toolchains may need a manual Triton install.
+
+## "CUDA out of memory" at the start of training
+
+Cheapest fixes first:
+1. Lower `fit_parameters.batch_size` (64 → 32 → 16 → 8).
+2. Set `fit_parameters.dtype` to `"bfloat16"` (bf16 autocast).
+3. Shrink the model: `fit_parameters.n_filters` (128 → 96).
+
+The default (batch 64, 2114 bp window, 9-layer/128-filter model) fits
+comfortably on a 16 GB GPU. Reducing batch size is cheapest; don't change model
+complexity without user input.
+
+## "The first iteration is very slow, then it speeds up"
+
+Not a bug — **Triton autotune** sweeping kernel configs on the first call, then
+caching the winner for the process. The first inference call autotunes
+separately. Nothing to fix.
+
+## "Training loss is NaN"
+
+By likelihood:
+1. **A peak with zero counts** makes the multinomial log-likelihood `-inf`. The
+   `min_counts`/`max_counts` filters are `PeakGenerator` arguments **not exposed
+   through the CLI JSON**, so the CLI fix is to **remove empty/zero-count peaks
+   from the peak BED upstream** before training. (`min_counts` is only reachable
+   by writing a custom Python loop with `cherimoya.io.PeakGenerator`.)
+2. **Mismatched strand counts** — stranded data passed flat (or unstranded data
+   as a pair) gives `y` the wrong shape. Set `verbose=true` and check the
+   train/validation shapes printed at startup. Confirm a stranded `(+, -)` pair
+   is nested (`[["plus.bw","minus.bw"]]`), not flat (see `input-files.md`).
+
+## "Validation Pearson is stuck near zero"
+
+1. **Validation chromosomes contain no peaks.** Check `Validation Set Size` at
+   startup — if ~0, your `validation_chroms` don't intersect your peaks. Common
+   when peaks are subset to one chromosome, or when the genome isn't hg38 and the
+   default chr8/chr20 split is wrong.
+2. **Controls were silently dropped.** A control-trained model evaluated without
+   controls collapses. The evaluate step must list the same `controls` as fit.
+3. **Train and validation signals differ** (e.g. different replicates) — a much
+   harder generalization problem than across-chromosome.
+4. **The signal is genuinely uninformative.** Sanity-check on a known-good target
+   (e.g. CTCF in K562 from ENCODE); if that converges, the issue is upstream of
+   Cherimoya.
+
+## "Is my dataset even big enough?"
+
+- **Peaks:** <2,000 → expect underfitting; 2,000–10,000 → workable, reduce
+  `n_filters` to 64-96; 10,000+ → defaults fine; 50,000+ → larger models
+  (`n_filters=192`/`256`) worth trying.
+- **Depth:** <~50 reads/peak → profile metrics noise-dominated (pool replicates
+  before peak calling); hundreds → normal; thousands (ATAC/DNase) →
+  signal-limited, not data-limited.
+
+## "MACS3 hangs or returns no peaks"
+
+- A large BAM can take ~10 min in MACS3 — normal.
+- Empty peak file on a small BAM → `callpeaks_q` too strict; try 0.1 or 0.5.
+- Wrong auto-detected format → set `preprocessing_parameters.callpeaks_format`
+  explicitly (e.g. `BAMPE` for paired-end).
+
+## "bam2bw couldn't open a remote URL"
+
+Streaming needs the remote store to support range requests. Public ENCODE HTTPS
+BAMs, S3-presigned URLs, and standard GCS objects work. Credentialed buckets
+need `AWS_*` / `GOOGLE_APPLICATION_CREDENTIALS` set first.
+
+## "torch.compile / CUDA-graph error at inference time"
+
+A `torch._dynamo`/`torch._inductor` traceback from inside `Cherimoya.forward`, or
+"accessing tensor output of CUDAGraphs that has been overwritten". The forward is
+wrapped in `torch.compile(mode='max-autotune')` by default. **If you don't
+immediately recognize the error, load with `compile=False`** — numerically
+identical, at the cost of the compile speedup:
+
+```python
+model = Cherimoya.load("checkpoint.torch", device="cuda", compile=False)
+# or keep autotuned kernels, skip only the CUDA graph:
+model = Cherimoya.load("checkpoint.torch", device="cuda",
+                       compile_mode='max-autotune-no-cudagraphs')
+```
+
+For fastest inference, call `model.eval()` before predicting so the megakernel
+reuses its bf16 weight cast.
+
+## "Cherimoya.load rejects a checkpoint" (`KeyError: 'config'` or a `weights_only` `RuntimeError`)
+
+The checkpoint was saved with the legacy `torch.save(model, ...)` path from
+before v0.1.0. It's not loadable by the current config-plus-state-dict loader;
+retrain with the current release. See `using-in-python.md` for the save/load
+format.
+
+## "The loaded model predicts differently than training reported"
+
+Not a mismatch. The saved checkpoint holds the **EMA-applied** weights, which
+produced the best validation numbers. Compare against the **EMA validation** row
+in `{name}.log`, not the mid-epoch training loss. See the checkpoint note in
+`interpreting-outputs.md`.

--- a/cherimoya_cli/skills/cherimoya/references/using-in-python.md
+++ b/cherimoya_cli/skills/cherimoya/references/using-in-python.md
@@ -1,0 +1,131 @@
+# Using Cherimoya from Python
+
+For programmatic use rather than the CLI. Most end-users don't need this, but
+"where is my trained model and how do I load it later" is a common follow-up.
+
+## The public API
+
+Only these symbols are public (`cherimoya/__init__.py`); everything else is
+private and may change between versions:
+
+- `Cherimoya` — the model.
+- `CheriBlock` — the building block.
+- `EMA` — the exponential-moving-average wrapper used during training.
+- `ControlWrapper`, `ProfileWrapper`, `LogCountWrapper`,
+  `ExpectedCountsWrapper` — output wrappers for analysis (see
+  `using-tangermeme.md`).
+
+## Constructing and calling a model
+
+```python
+import torch
+from cherimoya import Cherimoya
+
+model = Cherimoya(n_filters=128, n_layers=9).cuda()
+
+# X: one-hot DNA, shape (batch, 4, length). Length is arbitrary; the CLI and
+# quickstart use 2114, which yields the 1000 bp output window below.
+X = torch.randn(2, 4, 2114, device="cuda")
+with torch.no_grad():
+    y_profile, y_counts = model(X)
+
+y_profile.shape   # (2, 1, 1000)  — (batch, sum of group channels, out_window)
+y_counts.shape    # (2, 1)        — (batch, n_groups)
+```
+
+The forward **always returns a `(profile, log-count)` tuple.** The count head is
+trained against `log(count + 1)`.
+
+### Signal groups (single-task vs stranded vs multi-task)
+`signal_groups` describes the output tracks (mirrors the CLI `signals`
+grouping):
+- `signal_groups=[1]` (default) — one unstranded track (ATAC, DNase, …).
+- `signal_groups=[2]` — one stranded `(+, -)` group; two profile channels
+  sharing one count prediction.
+- `signal_groups=[1, 2]` — multi-task: unstranded plus stranded; `y_counts` has
+  shape `(batch, 2)`.
+
+### Control tracks
+Models trained with controls expect a control tensor every forward:
+`model(X, X_ctl)`. For analysis tools that pass only a sequence, wrap in
+`ControlWrapper` (see `using-tangermeme.md`) so a zero control is synthesized.
+
+## Saving and loading — the checkpoint format
+
+Checkpoints are a **config + `state_dict` bundle, not a pickled module.** This
+survives source-layout changes and is safe to load with `weights_only=True`.
+
+```python
+model.save("my_model.torch")
+
+model = Cherimoya.load("my_model.torch")                 # CPU by default
+model = Cherimoya.load("my_model.torch", device="cuda")  # onto a GPU
+```
+
+For fastest inference call `model.eval()` first.
+
+### Run inference under `torch.no_grad()` (megakernel)
+
+Cherimoya has a fused **inference megakernel** roughly **2× faster** than the
+default (training) forward, but it dispatches only when **the input is on a CUDA
+device and gradients are disabled** (GPU-only — CPU inputs always take the
+fallback). Wrap prediction in `torch.no_grad()` (or `torch.inference_mode()`);
+`model.eval()` alone does *not* disable grad, so without the wrapper the slower
+default kernel runs:
+
+```python
+model = model.eval()
+with torch.no_grad():                # required for the fast megakernel
+    y_profile, y_counts = model(X)
+```
+
+(The megakernel also requires `expansion * n_filters` to be a multiple of 16,
+which holds for the defaults: `2 * 128 = 256`.)
+
+### Choosing the `compile` setting — ask the user
+
+`Cherimoya.load` compiles the forward via two arguments: `compile` (bool,
+default `True`) and `compile_mode` (str, default `'max-autotune'`). This is a
+speed-vs-robustness trade-off — **ask the user before loading** rather than
+assuming the default:
+
+| Setting | How to load | Speed | Robustness |
+|---|---|---|---|
+| `max-autotune` (default) | `Cherimoya.load(path, device="cuda")` | Fastest | Can hit `torch.compile` / CUDA-graph errors on some setups |
+| `max-autotune-no-cudagraphs` | `Cherimoya.load(path, device="cuda", compile_mode='max-autotune-no-cudagraphs')` | Middle — keeps autotuned kernels, drops CUDA-graph capture | Avoids the CUDA-graph errors |
+| no compile | `Cherimoya.load(path, device="cuda", compile=False)` | Slowest (no compile speedup) | Most robust — sidesteps all compile/CUDA-graph foot-guns |
+
+All three are **numerically equivalent** and still run Cherimoya's Triton
+inference kernels; only the `torch.compile` wrapping differs. With
+`compile=False` the `compile_mode` value is ignored.
+
+Rules of thumb:
+- **Interactive / exploratory work, or after compile errors:** `compile=False`
+  is safest — the lost speedup (~10–20% on the megakernel) rarely matters at that
+  scale and it rules out an unrecognized `torch.compile`/CUDA-graph traceback
+  (see `troubleshooting.md`).
+- **Large-scale / high-throughput:** the default `max-autotune` is worth it; fall
+  back to `max-autotune-no-cudagraphs` on a CUDA-graph error, and to
+  `compile=False` only if that still fails.
+
+### Things to tell users about checkpoints
+
+- **Saved weights are the EMA shadow.** `model.fit(...)` applies the EMA average
+  before saving, so a loaded model reproduces the **EMA validation** numbers in
+  the log — not any mid-epoch training loss. Expected, not drift.
+- From a pipeline run, load **`{name}.torch`** (best validation count Pearson);
+  `{name}.final.torch` is the final-epoch EMA snapshot. See
+  `interpreting-outputs.md`.
+- **Legacy `torch.save(model, ...)` checkpoints (pre-0.1.0) are not loadable**
+  and must be retrained. Cherimoya is under active development and may break
+  checkpoint compatibility between versions — pin the version you train with if
+  you need to reload later.
+
+## Training in Python
+
+The CLI subcommands and `model.fit(...)` share this save format. For an
+end-to-end walkthrough (data loading, `fit()`, `predict()` signatures) see the
+Python API tutorial at
+<https://cherimoya.readthedocs.io/en/latest/tutorials/python_api.html>. For most
+"train on my data" requests the CLI pipeline (`cli-training-pipeline.md`) is the
+better tool than a hand-written loop.

--- a/cherimoya_cli/skills/cherimoya/references/using-tangermeme.md
+++ b/cherimoya_cli/skills/cherimoya/references/using-tangermeme.md
@@ -1,0 +1,65 @@
+# Analyzing a Cherimoya model with tangermeme
+
+Post-training analysis — attributions via saturation mutagenesis (ISM, the
+method Cherimoya uses), marginalization, variant-effect scoring, and sequence
+design — lives in **tangermeme**, not Cherimoya. (DeepLIFT/SHAP via
+`deep_lift_shap` is an alternative on a wrapped model.) Cherimoya's only job is
+to expose the right single tensor from its `(profile, log-count)` output.
+
+**If a `tangermeme` skill is available, invoke it for the actual analysis.**
+This file covers only the Cherimoya-specific step — choosing and applying the
+output wrapper — and does not duplicate tangermeme's API. Read the tangermeme
+skill/docs for the analysis call; don't guess its signature.
+
+## The wrappers (from `cherimoya`)
+
+tangermeme's tools expect a model returning a **single tensor**, but Cherimoya
+returns `(profile, log-count)`. Pick the wrapper for what you want to attribute
+or optimize:
+
+| Wrapper | Returns | Use for |
+|---|---|---|
+| `ProfileWrapper` | scalar per example from profile logits (weighted softmax) | profile **shape** |
+| `LogCountWrapper` | the log-count prediction | **total signal** (counts) at a locus |
+| `ExpectedCountsWrapper` | expected reads per base pair | per-position expected counts |
+| `ControlWrapper` | raw `(profile, log-count)`, synthesizing a zero control if needed | the **inner** wrapper for control-trained models |
+
+**`LogCountWrapper` (counts) is the recommended default; use `ProfileWrapper`
+when you care about profile shape.** `ControlWrapper` is the inner layer the
+profile/count wrappers sit on: for a control-trained model whose analysis tool
+passes only a sequence, it supplies a zero control of the right
+shape/dtype/device automatically. For a model with no controls it's a
+pass-through, so wrapping is always safe.
+
+## Pattern
+
+```python
+from cherimoya import Cherimoya
+from cherimoya import ControlWrapper
+from cherimoya import LogCountWrapper
+
+model = Cherimoya.load("my_run.torch", device="cuda")
+model = model.eval()
+
+# Attribute the counts (usual default); ControlWrapper handles a
+# control-trained model transparently. Swap in ProfileWrapper for shape.
+wrapper = LogCountWrapper(ControlWrapper(model))
+
+# Hand `wrapper` to tangermeme (saturation_mutagenesis, deep_lift_shap,
+# variant effect, ledidi design, ...).
+```
+
+## What lives where
+
+- **Cherimoya** — the model and the four wrappers above. Use these, not
+  bpnet-lite's.
+- **tangermeme** — `predict`, `saturation_mutagenesis`, `deep_lift_shap`,
+  `variant_effect`, `ersatz` (motif insertion), `seqlet.recursive_seqlets`,
+  `io.extract_loci`, MEME/bigWig/VCF loaders, plotting. Don't reimplement.
+- **ledidi** — gradient-based sequence design against a wrapped model, when the
+  user wants to *design* rather than *analyze*.
+
+The CLI already wires these for the standard flow (`attribute`, `seqlets`,
+`marginalize` in `cli-training-pipeline.md`). Reach for tangermeme directly only
+for something the pipeline doesn't do — a custom attribution target, variant
+scoring, or bespoke design objective.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -724,3 +724,25 @@ via ``subprocess.run(["cherimoya", "pipeline", "-p", jname])``.
    stranded pair); under the grouped API a flat two-element list is
    two *unstranded* tracks, so stranded batch jobs must use the
    nested form above.
+
+
+cherimoya install-skill
+-----------------------
+
+Install the bundled Cherimoya agent skill for `Claude Code
+<https://claude.com/claude-code>`_ into your skills directory, creating
+``cherimoya/`` inside it. The skill teaches the assistant to drive this CLI
+and the Python API — working out which inputs you have, choosing
+assay-appropriate settings, calling the right subcommands, and interpreting
+outputs — and to ask clarifying questions when an input is ambiguous.
+
+CLI flags:
+
+* ``-d, --directory`` — skills directory to install into. Default
+  ``~/.claude/skills``.
+* ``--symlink`` — symlink the packaged skill instead of copying it, so
+  in-place edits are reflected without reinstalling. Breaks if the install
+  location moves.
+* ``-f, --force`` — overwrite an existing installation at the destination.
+
+Restart Claude Code (or reload skills) to pick it up.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ cherimoya = "cherimoya_cli.__main__:main"
 [tool.setuptools]
 packages = ["cherimoya", "cherimoya_cli", "cherimoya_cli.commands"]
 
+[tool.setuptools.package-data]
+cherimoya_cli = ["skills/cherimoya/SKILL.md", "skills/cherimoya/references/*.md"]
+
 [tool.pytest.ini_options]
 markers = [
     "cuda: requires a CUDA device (skipped when no GPU is available)",

--- a/tests/test_install_skill.py
+++ b/tests/test_install_skill.py
@@ -1,0 +1,68 @@
+"""Tests for the cherimoya install-skill command.
+
+install-skill copies the bundled agent skill into a skills directory,
+creating a `cherimoya/` subdirectory that holds SKILL.md plus the
+references. A copy install must never carry `.ipynb_checkpoints`
+autosaves along (they exist in the working tree but must not ship into
+a user's skills directory), a collision without --force must error, and
+--force must overwrite.
+"""
+
+import argparse
+import os
+
+import pytest
+
+from cherimoya_cli.commands import install_skill
+
+
+def _run(tmp_path, symlink=False, force=False, directory=None):
+	args = argparse.Namespace(
+		directory=str(directory) if directory is not None else str(tmp_path),
+		symlink=symlink, force=force)
+	install_skill.run(args)
+	return os.path.join(
+		str(directory) if directory is not None else str(tmp_path),
+		"cherimoya")
+
+
+def test_copy_install_writes_skill_and_references(tmp_path):
+	dest = _run(tmp_path)
+	assert os.path.isfile(os.path.join(dest, "SKILL.md"))
+	refs = os.path.join(dest, "references")
+	assert os.path.isdir(refs)
+	# There is at least one reference and every one is a .md file.
+	names = os.listdir(refs)
+	assert any(name.endswith(".md") for name in names)
+
+
+def test_copy_install_excludes_ipynb_checkpoints(tmp_path):
+	"""Stale Jupyter autosaves in the source tree must not be copied."""
+	dest = _run(tmp_path)
+	for root, dirs, _ in os.walk(dest):
+		assert ".ipynb_checkpoints" not in dirs, (
+			"install-skill copied a .ipynb_checkpoints directory into "
+			"{}".format(root))
+
+
+def test_collision_without_force_errors(tmp_path):
+	_run(tmp_path)
+	with pytest.raises(FileExistsError):
+		_run(tmp_path)
+
+
+def test_force_overwrites_existing(tmp_path):
+	dest = _run(tmp_path)
+	# Drop a stray file; --force should wipe the directory before copying.
+	stray = os.path.join(dest, "stray.txt")
+	with open(stray, "w") as f:
+		f.write("x")
+	_run(tmp_path, force=True)
+	assert not os.path.exists(stray)
+	assert os.path.isfile(os.path.join(dest, "SKILL.md"))
+
+
+def test_symlink_install_points_at_source(tmp_path):
+	dest = _run(tmp_path, symlink=True)
+	assert os.path.islink(dest)
+	assert os.path.isfile(os.path.join(dest, "SKILL.md"))


### PR DESCRIPTION
## Summary

Adds a progressive-disclosure **Claude Code agent skill** distributed with the package, plus a `cherimoya install-skill` subcommand to install it.

- **Skill** (`cherimoya_cli/skills/cherimoya/`): a short `SKILL.md` router with three operating rules (ask-don't-guess, handle-missing-files-by-asking, use-defaults-and-explain) and topic-specific references loaded on demand — `cli-training-pipeline`, `input-files`, `assay-defaults`, `interpreting-outputs`, `troubleshooting`, `cli`, `using-in-python`, `using-tangermeme`, and a `concepts` primer. Aimed at users new to Cherimoya or sequence modeling.
- **`install-skill` command** (`cherimoya_cli/commands/install_skill.py`): copies (or `--symlink`s) the bundled skill into a skills directory (default `~/.claude/skills`), with `-d/--directory` and `-f/--force`. The copy path excludes `.ipynb_checkpoints/` so stale autosaves never ship into a user's skills directory.
- **Packaging**: `pyproject.toml` package-data ships the skill files.
- **Docs**: `docs/cli.rst` documents the new subcommand.
- **Tests**: `tests/test_install_skill.py` covers copy/symlink installs, collision handling, `--force`, and checkpoint exclusion.
- **README**: adds a skill section and corrects the public-symbol list (three → seven, including the four output wrappers).

## Testing

- `pytest -m "not cuda and not triton"` — 236 passed (+5 new).
- `sphinx-build -W -b html . _build/html` — build succeeded.
- `install-skill` verified to produce a clean 10-file tree (copy and symlink).

🤖 Generated with [Claude Code](https://claude.com/claude-code)