### PR TITLE
FIX stranded profile loss collapsing predictions onto one strand

### DIFF
--- a/cherimoya/cherimoya.py
+++ b/cherimoya/cherimoya.py
@@ -580,8 +580,10 @@ class Cherimoya(torch.nn.Module):
 				# `measures['profile_pearson']` is shape
 				# (n_loci, sum(signal_groups)); for each group, average
 				# over its channels and the locus dim so each modality
-				# contributes one number, matching how the loss is
-				# pooled and how the count Pearson is reported.
+				# contributes one number -- a per-group summary like the
+				# count Pearson. The Pearson metric stays per-channel and
+				# is scale-invariant, so this channel-average is unaffected
+				# by the loss's joint per-group normalization.
 				per_group_profile_corr = []
 				offset = 0
 				for g in self.signal_groups:

--- a/cherimoya/losses.py
+++ b/cherimoya/losses.py
@@ -22,14 +22,23 @@ def _mixture_loss(y, y_hat_logits, y_hat_logcounts, labels=None,
 
 	This function takes in the observed integer read counts, the predicted logits,
 	and the predicted logcounts, and returns per-*group* profile and count
-	losses. Each channel is treated as an independent multinomial along the
-	length dimension; the per-channel multinomial likelihoods are then
-	averaged within each signal group so every group contributes one
-	profile-loss term regardless of how many channels it contains. The
-	count loss is per-group by construction (one prediction per group). When
-	``signal_groups`` is None the function falls back to per-channel losses
-	(every channel is its own group for the purposes of this aggregation),
-	which matches the pre-grouping behavior.
+	losses. Each signal group is scored as a **single multinomial over its
+	channels and length jointly**: the group's channels are concatenated,
+	one ``log_softmax`` is taken over the flattened ``channels * length``
+	axis, and one MNLL is computed against the group's observed counts. This
+	matches how :class:`~cherimoya.wrappers.ExpectedCountsWrapper` distributes
+	a group's predicted counts across its channels and positions, so for a
+	stranded ``(+, -)`` pair the relative magnitude between the two strands
+	is part of the trained objective rather than an unconstrained per-channel
+	gauge. (A per-channel normalization leaves that relative offset free,
+	which lets a trained model collapse nearly all of a group's predicted
+	signal onto a single strand at inference — the joint normalization here
+	is what prevents that.) A single-channel (unstranded) group reduces
+	exactly to a per-length multinomial, so accessibility models are
+	unaffected. The count loss is per-group by construction (one prediction
+	per group). When ``signal_groups`` is None the function falls back to
+	per-channel losses (every channel is its own group), which matches the
+	pre-grouping behavior.
 
 
 	Parameters
@@ -58,9 +67,10 @@ def _mixture_loss(y, y_hat_logits, y_hat_logcounts, labels=None,
 		Default is None.
 
 	signal_groups: list of int or None, optional
-		Group sizes for the channel dimension of ``y``. When given, both
-		the per-channel profile MNLLs and the true counts are pooled per
-		group: a stranded ``(+, -)`` pair contributes one profile-loss
+		Group sizes for the channel dimension of ``y``. When given, each
+		group's channels are normalized jointly (a single multinomial over
+		the group's ``channels * length``) and the true counts are pooled
+		per group: a stranded ``(+, -)`` pair contributes one profile-loss
 		term and one count-target. ``sum(signal_groups)`` must equal
 		``y.shape[1]``. When None, every channel is treated as its own
 		group (legacy behavior). Default is None.
@@ -69,16 +79,15 @@ def _mixture_loss(y, y_hat_logits, y_hat_logcounts, labels=None,
 	Returns
 	-------
 	profile_loss: torch.Tensor, shape=(n_groups,) or (n_outputs,)
-		The per-group multinomial log likelihood (mean across the group's
-		channels then mean across examples). Falls back to per-channel
-		shape ``(n_outputs,)`` when ``signal_groups`` is None.
+		The per-group multinomial log likelihood (one joint multinomial
+		over the group's channels and length, mean across examples). Falls
+		back to per-channel shape ``(n_outputs,)`` when ``signal_groups``
+		is None.
 
 	count_loss: torch.Tensor, shape=(n_count_outputs,)
 		The per-group (or per-track) mean-squared error on log(count+1),
 		averaged across examples.
 	"""
-
-	log_probs = torch.nn.functional.log_softmax(y_hat_logits, dim=-1)
 
 	# Per-channel true counts: (n, n_outputs).
 	y_per_track = y.sum(dim=-1)
@@ -90,34 +99,55 @@ def _mixture_loss(y, y_hat_logits, y_hat_logcounts, labels=None,
 				"sum(signal_groups)={} does not match y.shape[1]={}"
 				.format(sum(signal_groups), y_per_track.shape[-1]))
 
-	# Profile loss: per-example per-channel MNLL, then mean over examples
-	# -> shape (n_outputs,).
+	# Restrict the profile loss to peak examples when labels are given;
+	# the count loss always runs on the full batch (below).
 	if labels is not None:
-		mnll = MNLLLoss(log_probs[labels == 1], y[labels == 1])
+		y_prof = y[labels == 1]
+		logits_prof = y_hat_logits[labels == 1]
 	else:
-		mnll = MNLLLoss(log_probs, y)
-	profile_loss = mnll.mean(dim=0)
+		y_prof = y
+		logits_prof = y_hat_logits
 
-	# Pool the per-channel profile MNLL into a per-group mean so every
-	# group contributes one loss term, regardless of channel count.
-	# Pool the per-channel true counts likewise so the count target is
-	# per-group. Both poolings are skipped for the all-size-one case
-	# (pure identity) to avoid an unnecessary copy.
+	# Profile loss. Each signal group is scored as a single multinomial
+	# over its channels and length jointly: the group's logits are
+	# flattened to (n, group_channels * length), one log_softmax is
+	# applied, and one MNLL is computed over the flattened axis. This
+	# couples a stranded (+, -) pair so the relative magnitude between its
+	# strands is part of the objective, matching how
+	# ExpectedCountsWrapper spreads a group's counts at inference.
+	#
+	# When every group is size one (the accessibility / unstranded
+	# multi-task case, and the signal_groups=None fallback) a joint
+	# softmax over a one-channel group is identical to a per-channel
+	# softmax over length, so this path is taken via the vectorized
+	# branch below and is bit-identical to the pre-grouping code.
+	groups = ([1] * y_prof.shape[1] if signal_groups is None
+		else list(signal_groups))
+
+	if all(g == 1 for g in groups):
+		log_probs = torch.nn.functional.log_softmax(logits_prof, dim=-1)
+		profile_loss = MNLLLoss(log_probs, y_prof).mean(dim=0)
+	else:
+		n = logits_prof.shape[0]
+		per_group = []
+		offset = 0
+		for g in groups:
+			logits_g = logits_prof[:, offset:offset+g].reshape(n, -1)
+			y_g = y_prof[:, offset:offset+g].reshape(n, -1)
+			log_probs_g = torch.nn.functional.log_softmax(logits_g, dim=-1)
+			per_group.append(MNLLLoss(log_probs_g, y_g).mean(dim=0))
+			offset += g
+		profile_loss = torch.stack(per_group)
+
+	# Per-group true counts (sum over each group's channels) so the count
+	# target matches the per-group count head. Skipped for the all-size-one
+	# case (pure identity) to avoid an unnecessary copy.
 	if signal_groups is not None and len(signal_groups) != y_per_track.shape[-1]:
 		groups_t = torch.tensor(signal_groups, device=y_per_track.device)
 		group_idx = torch.repeat_interleave(
 			torch.arange(len(signal_groups), device=y_per_track.device),
 			groups_t)
 
-		# Per-group profile loss: sum then divide by group size.
-		profile_per_group = torch.zeros(len(signal_groups),
-			device=profile_loss.device, dtype=profile_loss.dtype)
-		profile_per_group.index_add_(0, group_idx, profile_loss)
-		profile_per_group = profile_per_group / groups_t.to(
-			profile_loss.dtype)
-		profile_loss = profile_per_group
-
-		# Per-group true counts: sum.
 		n = y_per_track.shape[0]
 		y_per_group = torch.zeros(n, len(signal_groups),
 			device=y_per_track.device, dtype=y_per_track.dtype)

--- a/cherimoya_cli/skills/cherimoya/references/troubleshooting.md
+++ b/cherimoya_cli/skills/cherimoya/references/troubleshooting.md
@@ -43,6 +43,20 @@ By likelihood:
    train/validation shapes printed at startup. Confirm a stranded `(+, -)` pair
    is nested (`[["plus.bw","minus.bw"]]`), not flat (see `input-files.md`).
 
+## "Stranded predictions come almost entirely from one strand"
+
+A stranded `(+, -)` model (TF ChIP, PRO-cap, etc.) whose reconstructed
+`ExpectedCountsWrapper` profile has nearly all its signal on one strand,
+even though the observed data has comparable coverage on both (offset by
+~100-300 bp). Fixed in the **Unreleased** release: the profile loss now
+normalizes each signal group's channels **jointly** (one multinomial over
+both strands + length) instead of per-strand, so the strand balance is
+trained. Models trained with an older release have an uncalibrated
+strand offset baked into their weights — **retrain** with a current
+release to fix. Unstranded ATAC/DNase models are unaffected (the change
+is bit-identical for single-channel groups). See the CHANGELOG entry
+"Loss (breaking for stranded/multi-channel models)".
+
 ## "Validation Pearson is stuck near zero"
 
 1. **Validation chromosomes contain no peaks.** Check `Validation Set Size` at

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -118,11 +118,12 @@ Data pipeline (**breaking**)
   to which modality.
 * Every signal group now contributes one term to the loss
   regardless of how many channels it has. ``_mixture_loss``'s
-  profile component is averaged within each group (so a stranded
-  ``(+, -)`` pair's two per-strand MNLLs combine into one
-  per-group profile loss) before Kendall-Gal weighting; ``lw0``
-  drops from shape ``(sum(signal_groups),)`` to
-  ``(len(signal_groups),)``, matching ``lw1``. The summary log's
+  profile component combined a stranded ``(+, -)`` pair's two
+  per-strand MNLLs into one per-group profile loss before
+  Kendall-Gal weighting (this per-channel averaging was later
+  replaced by a joint per-group multinomial — see the Unreleased
+  entry above); ``lw0`` drops from shape ``(sum(signal_groups),)``
+  to ``(len(signal_groups),)``, matching ``lw1``. The summary log's
   ``Validation Profile Pearson`` now reports the mean over groups
   of (mean over the group's channels) so the headline metric
   agrees with the loss weighting — no double-counting of stranded

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -4,6 +4,36 @@ Changelog
 Unreleased
 ----------
 
+Loss (**breaking** for stranded/multi-channel models)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Fixed the profile loss so a multi-channel signal group is normalized
+  as a **single multinomial over its channels and length jointly**,
+  rather than one independent per-channel multinomial per strand then
+  averaged. Previously the relative additive offset between a stranded
+  ``(+, -)`` pair's logits was an unconstrained gauge (a per-channel
+  ``log_softmax`` over length is invariant to a per-channel shift), so a
+  trained model could place that offset arbitrarily. At inference,
+  :class:`cherimoya.wrappers.ExpectedCountsWrapper` distributes a
+  group's predicted counts with a *joint* softmax across the group's
+  channels and positions, which exponentiates that arbitrary offset and
+  collapses nearly all predicted signal onto a single strand — the
+  symptom being stranded TF models whose predictions came almost
+  entirely from one strand. The loss now matches the wrapper's joint
+  normalization, so the strand balance is a trained quantity.
+* **Single-channel (unstranded) models are unaffected — bit-for-bit.**
+  A joint softmax over a one-channel group is identical to a per-channel
+  softmax over length, so ATAC-seq / DNase-seq losses, gradients, and
+  training trajectories are unchanged and existing accessibility
+  checkpoints need no retraining. Only groups with two or more channels
+  (stranded TF / co-trained stranded modalities) change, and those
+  models should be **retrained** to benefit from the fix.
+* ``cherimoya.performance.calculate_performance_measures`` is
+  unchanged: ``profile_pearson`` / ``profile_spearman`` are invariant to
+  per-channel vs. joint normalization (both operate over the length axis
+  and are scale-invariant), and ``profile_jsd`` re-normalizes each
+  channel internally, so reported metrics are identical.
+
 Training defaults
 ~~~~~~~~~~~~~~~~~
 

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -189,11 +189,17 @@ Cherimoya uses a two-component loss, both terms pooled per signal
 group so every modality contributes equally regardless of channel
 count:
 
-* **Profile loss**: Per-channel multinomial negative log-likelihood
-  (MNLL) along the length axis, then averaged across the channels of
-  each signal group. A stranded ``(+, -)`` pair contributes one
-  profile-loss term (the mean of its two strands' MNLLs); an
-  unstranded track contributes one term directly.
+* **Profile loss**: One multinomial negative log-likelihood (MNLL)
+  per signal group, normalized **jointly** across the group's channels
+  and length — the group's channels are concatenated, a single
+  ``log_softmax`` is taken over the flattened ``channels * length``
+  axis, and one MNLL is computed against the group's counts. A stranded
+  ``(+, -)`` pair is therefore scored as a single distribution over
+  both strands, so the relative magnitude between the two strands is
+  part of the trained objective (a per-channel normalization would
+  leave it a free gauge and let the model collapse a group's signal
+  onto one strand at inference). An unstranded track reduces exactly to
+  a per-length multinomial.
 
 * **Counts loss**: ``log1pMSE`` between predicted log counts and
   ``log(1 + total_counts)``, computed per signal *group*. A stranded

--- a/docs/multi_task.rst
+++ b/docs/multi_task.rst
@@ -274,9 +274,10 @@ stranded TF pairs — 5 profile channels and 3 count predictions:
 
 **Loss.** Each group contributes exactly one profile-loss term and
 one count-loss term, regardless of how many channels it has. The
-ATAC group's profile MNLL is the per-channel MNLL of its one
-channel; each TF group's profile MNLL is the mean of its ``+`` and
-``-`` strand MNLLs. All three group-level profile losses then get
+ATAC group's profile MNLL is the per-length MNLL of its one channel;
+each TF group's profile MNLL is a single multinomial over its ``+``
+and ``-`` strands concatenated (normalized jointly, so the strand
+balance is learned). All three group-level profile losses then get
 weighted by Kendall-Gal uncertainty weights (``lw0`` is shape
 ``(3,)``), summed with the per-group count MSEs (also weighted by
 ``lw1`` shape ``(3,)``), and that's the total loss. The result is
@@ -392,9 +393,10 @@ two learnable weight tensors ``lw0`` and ``lw1`` both shape
 ``(len(signal_groups),)`` — one uncertainty weight per group on each
 side of the profile / counts split. Concretely:
 
-* The per-channel profile MNLL is averaged within each group, then
-  weighted by ``lw0``. A stranded pair contributes one profile-loss
-  term (the mean of its two strands' MNLLs), exactly the same
+* Each group's profile MNLL is a single multinomial over that group's
+  channels and length jointly, then weighted by ``lw0``. A stranded
+  pair contributes one profile-loss term (both strands normalized
+  together, so their relative magnitude is trained), exactly the same
   number of terms an unstranded track contributes.
 * The per-group count MSE is weighted by ``lw1`` directly.
 

--- a/docs/multi_task.rst
+++ b/docs/multi_task.rst
@@ -185,12 +185,15 @@ they swap under reverse-complement augmentation as a unit.
 ``+``, channel 1 = ``-``), ``(N, 2, out_window)``. One count
 prediction (the shared per-locus total), ``(N, 1)``.
 
-**Loss.** The two per-channel profile MNLLs are averaged into one
-per-group profile loss before Kendall-Gal weighting, so this
-configuration contributes one profile-loss term and one
-count-loss term — the same number of loss terms as the unstranded
-case. The Kendall-Gal weight tensors ``lw0`` and ``lw1`` are each
-shape ``(1,)``.
+**Loss.** The group's two strands are scored as a **single joint
+multinomial** — the ``+`` and ``-`` channels are concatenated and one
+``log_softmax`` is taken over the flattened ``channels * length`` — giving
+one per-group profile loss before Kendall-Gal weighting. Normalizing the
+strands together (rather than independently) makes their relative
+magnitude part of the trained objective. This configuration therefore
+contributes one profile-loss term and one count-loss term — the same
+number of loss terms as the unstranded case. The Kendall-Gal weight
+tensors ``lw0`` and ``lw1`` are each shape ``(1,)``.
 
 Python:
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -108,6 +108,28 @@ The most common causes, in order:
    when generating bigWigs) or cap with ``max_counts``.
 
 
+Stranded predictions come from only one strand
+----------------------------------------------
+
+Symptom: a stranded ``(+, -)`` model (TF ChIP, PRO-cap, ...) produces
+a reconstructed profile (via
+:class:`cherimoya.wrappers.ExpectedCountsWrapper`) with nearly all of
+its signal on one strand, even though the observed data has comparable
+coverage on both strands offset by ~100-300 bp.
+
+This was a profile-loss bug fixed in the **Unreleased** release. The
+loss previously normalized each strand of a group independently, which
+left the relative magnitude between strands an unconstrained gauge; the
+inference wrapper distributes a group's counts with a *joint* softmax
+across both strands, exponentiating that arbitrary offset and collapsing
+the signal onto one strand. The loss now normalizes each signal group's
+channels jointly, so the strand balance is a trained quantity. Models
+trained on an older release have the miscalibrated offset baked into
+their weights and must be **retrained**. Unstranded ATAC/DNase models
+are unaffected (the change is bit-identical for single-channel groups).
+See the :doc:`CHANGELOG`.
+
+
 Training Pearson is stuck near zero
 -----------------------------------
 

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -3,6 +3,8 @@
 import pytest
 import torch
 
+from bpnetlite.losses import MNLLLoss
+
 from cherimoya.losses import _mixture_loss
 
 
@@ -85,9 +87,9 @@ def test_mixture_loss_is_differentiable():
 def test_mixture_loss_signal_groups_pool_counts_per_group():
 	"""When signal_groups=[1, 2] is given, both the profile loss and
 	the count loss are per-group: the stranded pair contributes ONE
-	profile-loss term (mean of its two strands' MNLLs) and ONE count
-	target (sum of its two strands' counts). Each group thus
-	contributes equally to the total loss regardless of channel count."""
+	profile-loss term (a single joint multinomial over its two strands
+	and length) and ONE count target (sum of its two strands' counts).
+	Each group thus contributes one term regardless of channel count."""
 
 	# 3 channels: 1 unstranded + 1 stranded pair = 2 groups.
 	y, logits, _ = _toy_inputs(n_outputs=3)
@@ -100,8 +102,7 @@ def test_mixture_loss_signal_groups_pool_counts_per_group():
 	assert profile_loss.shape == (2,)  # one per group
 	assert count_loss.shape == (2,)    # one per group
 
-	# Sanity: per-group MSE matches hand-pooled y; per-group profile
-	# loss equals the mean of the per-channel losses for that group.
+	# Sanity: per-group MSE matches hand-pooled y.
 	y_per_track = y.sum(dim=-1)
 	y_per_group = torch.stack([
 		y_per_track[:, 0],
@@ -111,14 +112,100 @@ def test_mixture_loss_signal_groups_pool_counts_per_group():
 		).mean(dim=0)
 	assert torch.allclose(count_loss, expected_count, atol=1e-5)
 
-	# Re-derive the per-channel profile losses and pool to per-group.
-	per_channel = _mixture_loss(y, logits,
-		torch.zeros(y.shape[0], 3))[0]  # signal_groups=None -> shape (3,)
+	# Per-group profile loss is a single joint multinomial over the
+	# group's flattened (channels * length) axis. Group 0 (size 1) is a
+	# plain per-length multinomial of channel 0; group 1 (size 2) is one
+	# multinomial over channels 1 and 2 concatenated.
+	n = y.shape[0]
+	lp0 = torch.nn.functional.log_softmax(logits[:, 0:1].reshape(n, -1), dim=-1)
+	lp1 = torch.nn.functional.log_softmax(logits[:, 1:3].reshape(n, -1), dim=-1)
 	expected_profile = torch.stack([
-		per_channel[0],
-		(per_channel[1] + per_channel[2]) / 2,
+		MNLLLoss(lp0, y[:, 0:1].reshape(n, -1)).mean(dim=0),
+		MNLLLoss(lp1, y[:, 1:3].reshape(n, -1)).mean(dim=0),
 	])
 	assert torch.allclose(profile_loss, expected_profile, atol=1e-5)
+
+
+def test_mixture_loss_grouped_profile_matches_joint_multinomial():
+	"""A stranded (+, -) group's profile loss equals a single multinomial
+	over both strands concatenated — i.e. the two strands are normalized
+	jointly, not independently (the fix for the one-strand-collapse bug)."""
+
+	y, logits, _ = _toy_inputs(n_outputs=2)
+	logcounts = torch.zeros(y.shape[0], 1)
+
+	profile_loss, _ = _mixture_loss(y, logits, logcounts, signal_groups=[2])
+	assert profile_loss.shape == (1,)
+
+	n = y.shape[0]
+	log_probs = torch.nn.functional.log_softmax(logits.reshape(n, -1), dim=-1)
+	expected = MNLLLoss(log_probs, y.reshape(n, -1)).mean(dim=0)
+	assert torch.allclose(profile_loss, expected, atol=1e-5)
+
+
+def test_mixture_loss_grouped_profile_couples_strands():
+	"""Regression test for the one-strand-collapse bug. Under the joint
+	per-group normalization the profile loss must respond to the RELATIVE
+	offset between a group's strands: shifting one strand's logits by a
+	constant re-weights the multinomial and changes the loss. The pre-fix
+	per-channel normalization left that relative offset a free gauge
+	(loss invariant to it), which let a trained model dump nearly all of a
+	group's predicted counts onto a single strand at inference. A constant
+	shift applied to the WHOLE group is the true softmax gauge and must
+	leave the loss unchanged."""
+
+	y, logits, _ = _toy_inputs(n_outputs=2)
+	logcounts = torch.zeros(y.shape[0], 1)
+
+	base, _ = _mixture_loss(y, logits, logcounts, signal_groups=[2])
+
+	# Shift only the plus strand: the joint softmax MUST see this.
+	one_strand = logits.clone()
+	one_strand[:, 0] += 3.0
+	shifted, _ = _mixture_loss(y, one_strand, logcounts, signal_groups=[2])
+	assert not torch.allclose(base, shifted, atol=1e-4)
+
+	# Shift the whole group (both strands, all positions): pure gauge.
+	whole_group, _ = _mixture_loss(y, logits + 5.0, logcounts,
+		signal_groups=[2])
+	assert torch.allclose(base, whole_group, atol=1e-4)
+
+
+def test_mixture_loss_single_output_bit_identical_across_group_specs():
+	"""Single-output (unstranded, e.g. ATAC/DNase) models must be
+	completely unaffected by the grouped-normalization change: passing
+	signal_groups=None, [1], or omitting it entirely must all produce the
+	exact same profile and count losses, bit-for-bit. This is the
+	guarantee that accessibility checkpoints need no retraining."""
+
+	y, logits, logcounts = _toy_inputs(n_outputs=1, n_count_outputs=1)
+
+	prof_none, count_none = _mixture_loss(y, logits, logcounts)
+	prof_grp, count_grp = _mixture_loss(y, logits, logcounts,
+		signal_groups=[1])
+
+	# Exact equality (not allclose): same ops, same order.
+	assert torch.equal(prof_none, prof_grp)
+	assert torch.equal(count_none, count_grp)
+
+	# And both equal a hand-written per-channel multinomial.
+	log_probs = torch.nn.functional.log_softmax(logits, dim=-1)
+	expected_prof = MNLLLoss(log_probs, y).mean(dim=0)
+	assert torch.equal(prof_none, expected_prof)
+
+
+def test_mixture_loss_all_size_one_groups_bit_identical():
+	"""signal_groups=[1, 1, 1] (several unstranded co-trained tracks) must
+	be bit-identical to the per-channel signal_groups=None path for BOTH
+	the profile and count losses — the joint-normalization branch is never
+	entered when every group is size one."""
+
+	y, logits, logcounts = _toy_inputs(n_outputs=3, n_count_outputs=3)
+	prof_none, count_none = _mixture_loss(y, logits, logcounts)
+	prof_grp, count_grp = _mixture_loss(y, logits, logcounts,
+		signal_groups=[1, 1, 1])
+	assert torch.equal(prof_none, prof_grp)
+	assert torch.equal(count_none, count_grp)
 
 
 def test_mixture_loss_signal_groups_all_size_one_matches_legacy():

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -16,6 +16,24 @@ def _toy_inputs(n=2, n_outputs=1, length=8, n_count_outputs=1, seed=0):
 	return y, y_hat_logits, y_hat_logcounts
 
 
+def _legacy_single_output_profile_loss(y, logits, labels=None):
+	"""The pre-fix per-channel profile formula, reproducing ``main``'s fast
+	path exactly (per-channel ``log_softmax`` over length, then per-example
+	MNLL, then mean over examples). Used as a bitwise reference for the
+	accessibility no-op guarantee. This reference has been confirmed
+	bitwise-equal to ``main``'s actual ``_mixture_loss`` output — forward
+	values *and* gradients — via a cross-branch harness (see the PR
+	verification notes), so pinning the new code to it here is a valid
+	standing regression against the pre-grouping behavior."""
+
+	log_probs = torch.nn.functional.log_softmax(logits, dim=-1)
+	if labels is not None:
+		mnll = MNLLLoss(log_probs[labels == 1], y[labels == 1])
+	else:
+		mnll = MNLLLoss(log_probs, y)
+	return mnll.mean(dim=0)
+
+
 def test_mixture_loss_returns_per_track_vectors():
 	y, logits, logcounts = _toy_inputs()
 	profile_loss, count_loss = _mixture_loss(y, logits, logcounts)
@@ -192,6 +210,34 @@ def test_mixture_loss_single_output_bit_identical_across_group_specs():
 	log_probs = torch.nn.functional.log_softmax(logits, dim=-1)
 	expected_prof = MNLLLoss(log_probs, y).mean(dim=0)
 	assert torch.equal(prof_none, expected_prof)
+
+
+def test_mixture_loss_single_output_matches_legacy_forward_and_grad():
+	"""Single-output (ATAC/DNase) profile loss AND its gradient w.r.t. the
+	logits are bitwise-identical to the pre-fix per-channel formula, with
+	and without the ``labels`` filter and at a realistic output length.
+	This guards the accessibility no-op guarantee at the *gradient* level
+	(what actually drives training), not just the forward value, and pins
+	the reordered slice-then-softmax ``labels`` branch."""
+
+	for labels in (None, torch.tensor([1, 0, 1, 0])):
+		g = torch.Generator().manual_seed(3)
+		n = 4
+		y = torch.randint(0, 60, (n, 1, 200), generator=g).float()
+		base_logits = torch.randn(n, 1, 200, generator=g)
+		logcounts = torch.randn(n, 1, generator=g)
+
+		logits = base_logits.clone().requires_grad_(True)
+		profile_loss, _ = _mixture_loss(y, logits, logcounts, labels=labels,
+			signal_groups=[1])
+		profile_loss.sum().backward()
+
+		ref_logits = base_logits.clone().requires_grad_(True)
+		ref = _legacy_single_output_profile_loss(y, ref_logits, labels=labels)
+		ref.sum().backward()
+
+		assert torch.equal(profile_loss, ref)
+		assert torch.equal(logits.grad, ref_logits.grad)
 
 
 def test_mixture_loss_all_size_one_groups_bit_identical():


### PR DESCRIPTION
## Problem

Stranded `(+, -)` models (TF binding profiles) produced reconstructed profiles where nearly all predicted signal sat on **one strand**, even though the observed data has comparable coverage on both strands offset by ~100–300 bp. Unstranded accessibility models and reference BPNet-style models did not show this.

## Root cause

A train/predict **normalization mismatch** specific to multi-channel (stranded) groups:

- **Training:** the profile loss normalized each strand independently (a per-channel log-softmax over length), scoring the two strands as independent multinomials. A per-channel softmax is invariant to a per-channel additive shift, so the **relative offset between the plus and minus logit levels was an unconstrained gauge** — training never pinned it.
- **Inference:** the expected-counts reconstruction distributes a group's predicted counts with a **joint** softmax across the group's channels and positions. That exponentiates the arbitrary learned offset and collapses almost all probability mass onto one strand.

The reference BPNet-style loss avoids this by applying a single log-softmax across both strands in **both** training and inference.

## Fix

Normalize each signal group as **one multinomial over its channels and length jointly** in the profile loss, matching the inference reconstruction. This makes the strand balance part of the trained objective.

### Accessibility is bit-identical
A joint softmax over a one-channel group is identical to a per-channel softmax over length, so **unstranded ATAC-seq / DNase-seq losses, gradients, and training trajectories are unchanged** and existing accessibility checkpoints need no retraining. Only groups with ≥2 channels change; **stranded/TF models should be retrained**.

### Metrics unchanged
The profile Pearson/Spearman metrics operate over the length axis and are scale-invariant (joint vs per-channel differ only by a per-channel scalar), and profile JSD re-normalizes internally, so reported performance metrics are unaffected.

## Tests

- Grouped profile loss equals a single multinomial over both strands concatenated, and the loss now responds to a single-strand offset (the previously-free gauge) while staying invariant to a whole-group gauge shift.
- Bit-identity (`torch.equal`) guarantees for single-output and all-size-one specs, including a check that pins the accessibility path to the pre-fix formula for both the profile loss **and its gradient**, with and without the peak/negative label filter.

All loss/model/performance/IO/wrapper/fit-wiring tests pass.

## Verification: accessibility bit-identical (cross-branch, losses + gradients)

Predictions from a frozen checkpoint do **not** exercise the training loss (it runs only during fitting, not in the forward/predict path), so a prediction-parity check cannot detect a change to the single-output *training* loss. The authoritative check runs the previous loss against the new loss on identical inputs at realistic output length, comparing forward losses **and gradients** (`torch.equal`):

| Case | profile_loss | count_loss | logits_grad | logcounts_grad |
|---|---|---|---|---|
| `signal_groups=None` | ✅ | ✅ | ✅ | ✅ |
| `[1]` normal | ✅ | ✅ | ✅ | ✅ |
| `[1]` **with peak/negative labels** | ✅ | ✅ | ✅ | ✅ |
| `[1,1,1]` multi-track | ✅ | ✅ | ✅ | ✅ |
| `[1]` large counts | ✅ | ✅ | ✅ | ✅ |
| `[1]` bf16-origin logits | ✅ | ✅ | ✅ | ✅ |
| **`[2]` stranded (positive control)** | ❌ Δ≈2e4 | ✅ | ❌ Δ≈45 | ✅ |

All single-output/accessibility cases are bitwise identical (max-abs-diff 0) in both losses and gradients — including the label-filtered path, bf16-origin logits (as the autocast training loop produces), and large counts. The stranded `[2]` **positive control differs as expected**, confirming the harness is genuinely sensitive rather than trivially always-equal, and that only the profile term (not counts) changes even for stranded models.

Separately, a prediction check over ten unstranded accessibility experiments (ATAC and DNase, real validation-peak loci) is bitwise identical across branches — expected, since the prediction path is untouched.

## Docs
Changelog (flagged breaking for stranded models), architecture / multi-task / troubleshooting docs, and the CLI skill troubleshooting reference all updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
