### PR TITLE
RELEASE v0.2.0

### DIFF
--- a/cherimoya/__init__.py
+++ b/cherimoya/__init__.py
@@ -9,4 +9,4 @@ from .wrappers import ProfileWrapper
 from .wrappers import LogCountWrapper
 from .wrappers import ExpectedCountsWrapper
 
-__version__ = '0.1.1'
+__version__ = '0.2.0'

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -1,8 +1,20 @@
 Changelog
 =========
 
-Unreleased
-----------
+v0.2.0
+------
+
+Tooling
+~~~~~~~
+
+* Bundled a Claude Code agent skill under
+  ``cherimoya_cli/skills/cherimoya`` (a ``SKILL.md`` plus a
+  ``references/`` set) and shipped it as package data, so it installs
+  with the ``cherimoya`` package. Added a ``cherimoya install-skill``
+  subcommand that copies (or, with ``--symlink``, links) the bundled
+  skill into a Claude Code skills directory (``~/.claude/skills`` by
+  default), with ``--directory`` to pick another location and
+  ``--force`` to overwrite an existing install.
 
 Loss (**breaking** for stranded/multi-channel models)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@ sys.path.insert(0, os.path.abspath('..'))
 project = 'Cherimoya'
 copyright = '2026, Jacob Schreiber'
 author = 'Jacob Schreiber'
-release = '0.1.1'
+release = '0.2.0'
 
 # -- General configuration ---------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cherimoya"
-version = "0.1.1"
+version = "0.2.0"
 description = "A light-weight deep learning architecture that uses modern optimization tricks to achieve strong predictive performance."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Release v0.2.0.

## Highlights
- **Bundled Claude Code agent skill** (`cherimoya_cli/skills/cherimoya`) shipped as package data, plus a `cherimoya install-skill` subcommand to copy/symlink it into a Claude Code skills directory.
- Stranded/multi-channel profile **loss fix** (breaking for stranded models; single-channel unaffected).
- Default training `batch_size` now 64 (was 192).

## Release mechanics
- Version bumped to `0.2.0` in `pyproject.toml`, `cherimoya/__init__.py`, and `docs/conf.py`.
- `docs/CHANGELOG.rst`: renamed the `Unreleased` section to `v0.2.0` and added the missing skill / `install-skill` entry.
- Verified `sdist` + `wheel` **include** all 11 skill files and **exclude** `CLAUDE.md` (and any `.ipynb_checkpoints`).
- `pytest` (CPU): 241 passed. Strict Sphinx build (`-W`): succeeded.
- Tag `v0.2.0` pushed to origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)