### PR TITLE
ADD GHCR container publishing workflow, OCI labels, and pull docs

### DIFF
--- a/.github/workflows/publish-container.yaml
+++ b/.github/workflows/publish-container.yaml
@@ -1,0 +1,28 @@
+name: Publish container
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: version
+        run: echo "version=$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')" >> "$GITHUB_OUTPUT"
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de AS main
 
+LABEL org.opencontainers.image.title=cherimoya
+LABEL org.opencontainers.image.source=https://github.com/jmschrei/cherimoya
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc libc6-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ git clone https://github.com/jmschrei/cherimoya.git
 cd cherimoya && pip install -e .
 ```
 
-Or pull the prebuilt Docker image:
+Or pull the prebuilt Docker image, published to the GitHub Container Registry on every push to `main`:
 
 ```bash
-docker pull ramirc1/cherimoya:latest      # or pin a version: ramirc1/cherimoya:0.2.0
+docker pull ghcr.io/jmschrei/cherimoya:latest      # or pin a version: ghcr.io/jmschrei/cherimoya:0.2.0
 ```
 
 GPU acceleration requires Triton and a CUDA-capable device; a pure-PyTorch CPU fallback is available for everything except the inference megakernel. See [the installation guide](https://cherimoya.readthedocs.io/en/latest/installation.html) for Triton compatibility notes.


### PR DESCRIPTION
Publish the image to the GitHub Container Registry on every push to main, tagged with both latest and the pyproject version. Add org.opencontainers.image.title/source labels so GHCR links the package to the repo, and point the README pull instructions at ghcr.io/jmschrei/cherimoya.