### PR TITLE
FIX Dockerfile editable install so cherimoya imports in runtime stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-install-project
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen
+    uv sync --frozen --no-editable
 
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de AS main
 


### PR DESCRIPTION
uv installs the project editable by default (uv.lock: source = editable), leaving a .pth pointing at /work that the main stage never copies. Use --no-editable so the venv is self-contained.