### PR TITLE
FIX attribute idxs/n_idxs mask size mismatch when loci are dropped

### DIFF
--- a/cherimoya_cli/commands/attribute.py
+++ b/cherimoya_cli/commands/attribute.py
@@ -38,8 +38,7 @@ def run(args):
 
     n_idxs = X.sum(dim=(1, 2)) == X.shape[-1]
     X = X[n_idxs]
-
-    idxs[~n_idxs] = False
+    idxs[idxs.clone()] = n_idxs
 
     model = ControlWrapper(model)
     if parameters["output"] == "counts":


### PR DESCRIPTION
extract_loci drops loci near chromosome ends, so X (only kept loci) is shorter than the returned mask idxs (all input loci). Masking idxs with ~n_idxs, which lives in X-row space, raised an IndexError whenever any locus was dropped. Project the ambiguous-base filter back into peak space with idxs[idxs.clone()] = n_idxs so the saved idx array stays aligned with X.