### PR TITLE
Refactor CheriBlock Fused Dilated Convolution for DeepLIFT Compatibility + Legacy Checkpoint Support

### DIFF
--- a/cherimoya/cheri.py
+++ b/cherimoya/cheri.py
@@ -792,6 +792,12 @@ class FusedDilatedConvNorm(torch.nn.Module):
 	inline) gives attribution methods that walk the module tree, such as
 	DeepLIFT, a concrete node to hook or substitute.
 
+	One asymmetry to know about: the inference megakernel calls the fused
+	op directly rather than through this module, so hooks registered here
+	fire on the CPU and Triton training paths but not under ``no_grad`` on
+	CUDA. Attribution runs need gradients and so always take the training
+	path; code capturing activations at inference time does not.
+
 	Parameters
 	----------
 	n_filters: int

--- a/cherimoya/cheri.py
+++ b/cherimoya/cheri.py
@@ -806,14 +806,47 @@ class FusedDilatedConvNorm(torch.nn.Module):
 		self.n_filters = n_filters
 		self.dilation = dilation
 
+		# Allocated here but *not* initialized here. CheriBlock applies
+		# trunc_normal_ after building linear1/linear2 so that the
+		# sequence of RNG draws matches pre-submodule versions exactly
+		# and a given seed reproduces the same block. Do not fold the
+		# init back into this constructor.
 		self.conv_weight = torch.nn.Parameter(torch.randn(3, n_filters))
-		torch.nn.init.trunc_normal_(self.conv_weight, std=0.02)
 
 	def forward(self, X):
 		assert X.ndim == 3, f"expected (N, L, C), got {tuple(X.shape)}"
 		assert X.shape[-1] == self.n_filters, (
 			f"channel dim {X.shape[-1]} != n_filters {self.n_filters}")
 		return fused_dilated_conv_norm(X, self.conv_weight, self.dilation)
+
+
+def _rename_conv_key(module, destination, prefix, _local_metadata):
+	"""Emit the depthwise weight under its pre-submodule name.
+
+	The parameter now lives on ``block.conv``, so a naive state dict
+	would key it as ``conv.conv_weight``. Thousands of trained models
+	and any number of installed copies of this package expect
+	``conv_weight``, and a released version reading a checkpoint with
+	the new key fails outright rather than degrading. Renaming on the
+	way out keeps the on-disk format frozen, so checkpoints stay
+	readable in both directions; `CheriBlock._load_from_state_dict`
+	handles the other half by accepting either name on the way in.
+
+	The rename rebuilds the dict rather than pop-and-reassign so that
+	the key keeps its original position, leaving the serialized key
+	order byte-for-byte what it has always been.
+	"""
+
+	new_key = prefix + 'conv.conv_weight'
+	if new_key not in destination:
+		return
+
+	old_key = prefix + 'conv_weight'
+	items = [(old_key if k == new_key else k, v)
+		for k, v in destination.items()]
+
+	destination.clear()
+	destination.update(items)
 
 
 class CheriBlock(torch.nn.Module):
@@ -852,9 +885,11 @@ class CheriBlock(torch.nn.Module):
 	  Any case that fails these conditions falls back to the training
 	  path, so existing model configurations keep working unchanged.
 
-	Existing trained checkpoints are bit-compatible: the parameter
-	layout, init order, and forward semantics of the training path are
-	unchanged. The inference megakernel produces outputs that differ
+	Existing trained checkpoints are bit-compatible: the init order and
+	the forward semantics of the training path are unchanged, and the
+	depthwise weight is read and written under its historical
+	``conv_weight`` key even though it now lives on the ``conv``
+	submodule. The inference megakernel produces outputs that differ
 	from the training path by at most ~1e-5 max-abs at unit-scale
 	outputs; this drift comes from bf16 weight casts in the MLP and is
 	the precision/speed tradeoff documented in ``_cast_weights``.
@@ -893,6 +928,7 @@ class CheriBlock(torch.nn.Module):
 		self.linear2 = torch.nn.Linear(hidden, n_filters, bias=False)
 		self.activation = torch.nn.GELU(approximate='tanh')
 
+		torch.nn.init.trunc_normal_(self.conv.conv_weight, std=0.02)
 		torch.nn.init.trunc_normal_(self.linear1.weight, std=0.02)
 		torch.nn.init.trunc_normal_(self.linear2.weight, std=0.02)
 
@@ -921,12 +957,34 @@ class CheriBlock(torch.nn.Module):
 				m.train(False)
 		self.register_load_state_dict_post_hook(_refresh)
 
+		# Write the depthwise weight out under its historical name so
+		# that checkpoints saved here stay readable by installs that
+		# predate the FusedDilatedConvNorm submodule. See
+		# `_rename_conv_key` for the details.
+		self.register_state_dict_post_hook(_rename_conv_key)
+
+	@property
+	def conv_weight(self):
+		"""The depthwise convolution weight, of shape ``(3, n_filters)``.
+
+		Read-only alias for ``self.conv.conv_weight``. The parameter used
+		to live directly on the block and moved onto the
+		``FusedDilatedConvNorm`` submodule so that attribution methods
+		which walk the module tree have a node to hook. Code that reaches
+		for ``block.conv_weight`` keeps working and gets the same object
+		back; assign through ``block.conv.conv_weight`` instead.
+		"""
+
+		return self.conv.conv_weight
+
 	def _load_from_state_dict(self, state_dict, prefix, *args, **kwargs):
 		"""Load parameters, migrating checkpoints that predate ``self.conv``.
 
 		Older CheriBlocks held the depthwise weight directly on the block
 		as ``conv_weight``; it now lives on the ``FusedDilatedConvNorm``
-		submodule as ``conv.conv_weight``.
+		submodule as ``conv.conv_weight``. Checkpoints are written in the
+		old format (see `_rename_conv_key`), so this covers both those and
+		any state dict produced by a bare ``named_parameters`` walk.
 		"""
 
 		old_key = prefix + 'conv_weight'

--- a/cherimoya/cheri.py
+++ b/cherimoya/cheri.py
@@ -792,10 +792,6 @@ class FusedDilatedConvNorm(torch.nn.Module):
 	inline) gives attribution methods that walk the module tree, such as
 	DeepLIFT, a concrete node to hook or substitute.
 
-	The depthwise convolution weight lives here rather than on the parent
-	``CheriBlock``. ``CheriBlock.__setstate__`` migrates checkpoints that
-	predate this move.
-
 	Parameters
 	----------
 	n_filters: int

--- a/cherimoya/cheri.py
+++ b/cherimoya/cheri.py
@@ -783,6 +783,43 @@ def fused_dilated_conv_norm(x, w, dilation):
 	return _cheri_conv_norm_cpu(x, w, dilation)
 
 
+class FusedDilatedConvNorm(torch.nn.Module):
+	"""nn.Module wrapper around the fused dilated conv + per-example norm.
+
+	This wrapper adds only Python-level module dispatch -- the underlying
+	kernel and its launches are unchanged, and the op stays fused. Owning
+	the operation as a module (rather than calling the autograd Function
+	inline) gives attribution methods that walk the module tree, such as
+	DeepLIFT, a concrete node to hook or substitute.
+
+	The depthwise convolution weight lives here rather than on the parent
+	``CheriBlock``. ``CheriBlock.__setstate__`` migrates checkpoints that
+	predate this move.
+
+	Parameters
+	----------
+	n_filters: int
+		The number of channels (the C dimension).
+
+	dilation: int
+		Spacing between the three taps.
+	"""
+
+	def __init__(self, n_filters, dilation):
+		super().__init__()
+		self.n_filters = n_filters
+		self.dilation = dilation
+
+		self.conv_weight = torch.nn.Parameter(torch.randn(3, n_filters))
+		torch.nn.init.trunc_normal_(self.conv_weight, std=0.02)
+
+	def forward(self, X):
+		assert X.ndim == 3, f"expected (N, L, C), got {tuple(X.shape)}"
+		assert X.shape[-1] == self.n_filters, (
+			f"channel dim {X.shape[-1]} != n_filters {self.n_filters}")
+		return fused_dilated_conv_norm(X, self.conv_weight, self.dilation)
+
+
 class CheriBlock(torch.nn.Module):
 	"""A single Cheri Block.
 
@@ -855,12 +892,11 @@ class CheriBlock(torch.nn.Module):
 
 		hidden = expansion * n_filters
 
-		self.conv_weight = torch.nn.Parameter(torch.randn(3, n_filters))
+		self.conv = FusedDilatedConvNorm(n_filters, dilation)
 		self.linear1 = torch.nn.Linear(n_filters, hidden, bias=False)
 		self.linear2 = torch.nn.Linear(hidden, n_filters, bias=False)
 		self.activation = torch.nn.GELU(approximate='tanh')
 
-		torch.nn.init.trunc_normal_(self.conv_weight, std=0.02)
 		torch.nn.init.trunc_normal_(self.linear1.weight, std=0.02)
 		torch.nn.init.trunc_normal_(self.linear2.weight, std=0.02)
 
@@ -888,6 +924,22 @@ class CheriBlock(torch.nn.Module):
 			if not m.training:
 				m.train(False)
 		self.register_load_state_dict_post_hook(_refresh)
+
+	def _load_from_state_dict(self, state_dict, prefix, *args, **kwargs):
+		"""Load parameters, migrating checkpoints that predate ``self.conv``.
+
+		Older CheriBlocks held the depthwise weight directly on the block
+		as ``conv_weight``; it now lives on the ``FusedDilatedConvNorm``
+		submodule as ``conv.conv_weight``.
+		"""
+
+		old_key = prefix + 'conv_weight'
+		new_key = prefix + 'conv.conv_weight'
+
+		if old_key in state_dict and new_key not in state_dict:
+			state_dict[new_key] = state_dict.pop(old_key)
+
+		super()._load_from_state_dict(state_dict, prefix, *args, **kwargs)
 
 	def train(self, mode=True):
 		"""Set training mode and (un)populate the eval-time bf16 cache.
@@ -962,9 +1014,9 @@ class CheriBlock(torch.nn.Module):
 
 		if self._can_use_inference_path(X):
 			w1, w2 = self._cast_weights(X)
-			return _fwd_inf_forward(X, self.conv_weight, self.dilation,
+			return _fwd_inf_forward(X, self.conv.conv_weight, self.dilation,
 				w1, w2)
 
-		X_conv = fused_dilated_conv_norm(X, self.conv_weight, self.dilation)
+		X_conv = self.conv(X)
 		X_mlp = self.linear2(self.activation(self.linear1(X_conv)))
 		return X + X_mlp * self.residual_scale

--- a/cherimoya/cherimoya.py
+++ b/cherimoya/cherimoya.py
@@ -23,6 +23,14 @@ from bpnetlite.logging import Logger
 torch.set_float32_matmul_precision('high')
 
 
+class _Log(torch.nn.Module):
+    def __init__(self):
+        super(_Log, self).__init__()
+
+    def forward(self, X):
+        return torch.log(X)
+
+	
 class EMA:
 	"""Exponential moving average of a model's parameters.
 
@@ -187,6 +195,7 @@ class Cherimoya(torch.nn.Module):
 
 		self.lw0 = torch.nn.Parameter(torch.ones(self.n_groups))
 		self.lw1 = torch.nn.Parameter(torch.ones(self.n_groups))
+		self._log = _Log()
 
 		torch.nn.init.trunc_normal_(self.iconv.weight, std=0.02)
 		torch.nn.init.trunc_normal_(self.fconv.weight, std=0.02)
@@ -388,7 +397,7 @@ class Cherimoya(torch.nn.Module):
 		if X_ctl is not None:
 			X_ctl = torch.sum(X_ctl[:, :, start:end].float(), dim=(1, 2))
 			X_ctl = X_ctl.unsqueeze(-1)
-			X = torch.cat([X, torch.log(X_ctl+1)], dim=-1)
+			X = torch.cat([X, self._log(X_ctl+1)], dim=-1)
 
 		y_counts = self.linear(X)
 		return y_profile, y_counts

--- a/cherimoya/cherimoya.py
+++ b/cherimoya/cherimoya.py
@@ -24,13 +24,20 @@ torch.set_float32_matmul_precision('high')
 
 
 class _Log(torch.nn.Module):
-    def __init__(self):
-        super(_Log, self).__init__()
+	"""A module wrapper around ``torch.log``.
 
-    def forward(self, X):
-        return torch.log(X)
+	Owning the log as a module (rather than calling ``torch.log`` inline)
+	gives attribution methods that walk the module tree, such as DeepLIFT,
+	a concrete node to register a non-linear op against.
+	"""
 
-	
+	def __init__(self):
+		super(_Log, self).__init__()
+
+	def forward(self, X):
+		return torch.log(X)
+
+
 class EMA:
 	"""Exponential moving average of a model's parameters.
 

--- a/cherimoya_cli/commands/fit.py
+++ b/cherimoya_cli/commands/fit.py
@@ -2,6 +2,56 @@
 # Author: Jacob Schreiber <jmschreiber91@gmail.com>
 
 
+def _split_parameters(model):
+    """Route each trainable parameter to one of the three optimizers.
+
+    Muon takes 2D projection weights inside Cheri Blocks
+    (linear1/linear2.weight). ``conv_weight`` is 2D but lives on the
+    depth-wise dilated path, not a projection matmul, and is routed to
+    AdamW -- note the test is a substring, so it matches whether the
+    parameter sits directly on the block or on its ``conv`` submodule.
+    ``lw0`` / ``lw1`` are the Kendall loss-balancing weights and are
+    routed by exact name to SGD. Everything else goes to AdamW.
+
+    Every parameter lands in exactly one bucket, so the three lists
+    partition ``model.named_parameters()``.
+
+    Parameters
+    ----------
+    model: torch.nn.Module
+            The model whose parameters are being routed.
+
+    Returns
+    -------
+    muon_params: list
+            2D projection weights, for the Muon optimizer.
+
+    adam_params: list
+            Everything not claimed by the other two, for AdamW.
+
+    lw_params: list
+            The Kendall loss-balancing weights, for SGD.
+    """
+
+    muon_params = []
+    adam_params = []
+    lw_params = []
+    for name, p in model.named_parameters():
+        if name in ("lw0", "lw1"):
+            lw_params.append(p)
+        elif (
+            p.ndim == 2
+            and "weight" in name
+            and name != "linear.weight"
+            and "conv_weight" not in name
+        ):
+            muon_params.append(p)
+        else:
+            adam_params.append(p)
+
+    return muon_params, adam_params, lw_params
+
+
 def run(args):
     import argparse
     import copy
@@ -152,25 +202,7 @@ def run(args):
     num_warmup_iters = len(training_data) * n_warmup_epochs
     num_decay_iters = len(training_data) * max(1, max_epochs - n_warmup_epochs)
 
-    # Muon takes 2D projection weights inside Cheri Blocks
-    # (linear1/linear2.weight). ``conv_weight`` is 2D but lives on the
-    # depth-wise dilated path, not a projection matmul, and is routed to
-    # AdamW. ``lw0`` / ``lw1`` are routed by exact name to SGD.
-    muon_params = []
-    adam_params = []
-    lw_params = []
-    for name, p in model.named_parameters():
-        if name in ("lw0", "lw1"):
-            lw_params.append(p)
-        elif (
-            p.ndim == 2
-            and "weight" in name
-            and name != "linear.weight"
-            and "conv_weight" not in name
-        ):
-            muon_params.append(p)
-        else:
-            adam_params.append(p)
+    muon_params, adam_params, lw_params = _split_parameters(model)
 
     muon_optimizer = Muon(
         muon_params, lr=parameters["muon_lr"], weight_decay=parameters["muon_wd"]

--- a/cherimoya_cli/commands/fit.py
+++ b/cherimoya_cli/commands/fit.py
@@ -264,8 +264,7 @@ def run(args):
     model_name = parameters["name"] or model.name
 
     evaluate_parameters = copy.deepcopy(parameters)
-    # evaluate_parameters["chroms"] = parameters["validation_chroms"]
-    evaluate_parameters["chroms"] = parameters["test_chroms"]
+    evaluate_parameters["chroms"] = parameters["validation_chroms"]
     evaluate_parameters["max_jitter"] = 0
     evaluate_parameters["reverse_complement"] = False
     evaluate_parameters["model"] = model_name + ".torch"

--- a/cherimoya_cli/commands/fit.py
+++ b/cherimoya_cli/commands/fit.py
@@ -264,7 +264,8 @@ def run(args):
     model_name = parameters["name"] or model.name
 
     evaluate_parameters = copy.deepcopy(parameters)
-    evaluate_parameters["chroms"] = parameters["validation_chroms"]
+    # evaluate_parameters["chroms"] = parameters["validation_chroms"]
+    evaluate_parameters["chroms"] = parameters["test_chroms"]
     evaluate_parameters["max_jitter"] = 0
     evaluate_parameters["reverse_complement"] = False
     evaluate_parameters["model"] = model_name + ".torch"

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -20,6 +20,11 @@ Attribution
   than through ``block.conv``, so hooks on that submodule fire on the CPU
   and Triton training paths but not under ``no_grad`` on CUDA.
   Attribution is unaffected, since it runs with gradients enabled.
+* Nothing is registered against the new nodes by default. An attribution
+  method only acts on a module it has been given a rule for, so runs that
+  do not mention these two classes behave exactly as they did before —
+  the nodes exist to be opted into, and adding them changes no existing
+  result.
 
 Compatibility
 ~~~~~~~~~~~~~
@@ -30,7 +35,23 @@ Compatibility
   the parameter now lives at ``block.conv.conv_weight``. Checkpoints
   round-trip between this version and earlier ones in both directions,
   and loading a pre-existing model reproduces identical forward output,
-  input gradients, and parameter gradients.
+  input gradients, and parameter gradients. Loading accepts either
+  spelling, so a state dict assembled by hand or from a
+  ``named_parameters()`` walk loads as well.
+* The parameter's *name* does change even though its checkpoint key does
+  not. ``named_parameters()`` now reports ``blocks.N.conv.conv_weight``
+  where it reported ``blocks.N.conv_weight``, and the module tree gains a
+  ``blocks.N.conv`` node per block plus a model-level ``_log``. Code that
+  matches parameter names by substring is unaffected — including the
+  Muon / AdamW / SGD split in ``cherimoya fit``, whose ``conv_weight``
+  exclusion is a substring test and still routes every parameter to the
+  optimizer it went to before. What needs the new name is anything that
+  looks the parameter up *exactly* by its ``named_parameters()`` name —
+  ``dict(model.named_parameters())["blocks.0.conv_weight"]`` now raises
+  ``KeyError``, as does any per-parameter map (learning rates, weight
+  decay, a hand-rolled EMA) built before the change and keyed by name.
+  Attribute-path lookups are fine: ``model.get_parameter`` resolves
+  through the alias property, so both spellings return the parameter.
 * Block initialization draws from the RNG in the same order as before, so
   a given seed still rebuilds an identical block.
 * ``CheriBlock.conv_weight`` remains available as a read-only property

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -16,6 +16,10 @@ Attribution
   prerequisite for correct DeepLIFT support. The kernels, the conditions
   under which each forward path dispatches, and the numerics are all
   unchanged.
+* Note that the inference megakernel calls the fused op directly rather
+  than through ``block.conv``, so hooks on that submodule fire on the CPU
+  and Triton training paths but not under ``no_grad`` on CUDA.
+  Attribution is unaffected, since it runs with gradients enabled.
 
 Compatibility
 ~~~~~~~~~~~~~

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -1,6 +1,40 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+Attribution
+~~~~~~~~~~~
+
+* The fused dilated convolution + per-example norm inside
+  :class:`cherimoya.CheriBlock` now lives on a ``FusedDilatedConvNorm``
+  submodule (``block.conv``), and the control-track log inside
+  :class:`cherimoya.Cherimoya` on a ``_Log`` submodule, rather than being
+  called inline. Attribution methods that walk the module tree — DeepLIFT
+  and SHAP in particular — now have concrete nodes to hook, which is a
+  prerequisite for correct DeepLIFT support. The kernels, the conditions
+  under which each forward path dispatches, and the numerics are all
+  unchanged.
+
+Compatibility
+~~~~~~~~~~~~~
+
+* **Existing checkpoints are unaffected — bit-for-bit.** The depthwise
+  weight is still written to and read from ``state_dict`` under its
+  historical ``conv_weight`` key, in its original position, even though
+  the parameter now lives at ``block.conv.conv_weight``. Checkpoints
+  round-trip between this version and earlier ones in both directions,
+  and loading a pre-existing model reproduces identical forward output,
+  input gradients, and parameter gradients.
+* Block initialization draws from the RNG in the same order as before, so
+  a given seed still rebuilds an identical block.
+* ``CheriBlock.conv_weight`` remains available as a read-only property
+  aliasing ``block.conv.conv_weight``, and reads return the same object.
+  Assignment through it now raises instead of silently leaving the
+  submodule holding the old parameter — assign to
+  ``block.conv.conv_weight`` instead.
+
 v0.2.1
 ------
 

--- a/docs/api/cheri.rst
+++ b/docs/api/cheri.rst
@@ -33,6 +33,46 @@ to the pure-PyTorch fallback (``_cheri_conv_norm_cpu``). Numerically
 equivalent up to floating-point error.
 
 
+FusedDilatedConvNorm
+--------------------
+
+.. autoclass:: FusedDilatedConvNorm
+   :members: forward
+   :undoc-members:
+   :show-inheritance:
+
+   .. rubric:: Constructor
+
+   .. automethod:: __init__
+
+An ``nn.Module`` wrapper around :func:`fused_dilated_conv_norm`, held by
+each :class:`CheriBlock` as ``block.conv``. It owns the depthwise weight
+(``block.conv.conv_weight``) and adds nothing but module dispatch — the
+kernel, its launches, and the numerics are identical to calling the
+function directly.
+
+Its purpose is to give attribution methods that discover their targets by
+walking ``named_modules`` — DeepLIFT and SHAP in particular — a concrete
+node to hook or substitute. Registering a handler for it is the caller's
+job; the module is inert on its own, so an attribution run that does not
+mention it behaves exactly as it did before this class existed.
+
+.. note::
+
+   The inference megakernel calls the fused op directly rather than
+   through this submodule, so hooks registered on ``block.conv`` fire on
+   the CPU and Triton training paths but **not** under ``no_grad`` on
+   CUDA. Attribution runs are unaffected, since they need gradients and
+   therefore take the training path.
+
+.. warning::
+
+   Do not confuse this with :class:`FusedDilatedConvNormFunc` below. The
+   module is the hookable node in the tree; the ``Func`` is the
+   ``torch.autograd.Function`` implementing the fused kernel that the
+   module ultimately calls.
+
+
 FusedDilatedConvNormFunc
 ------------------------
 
@@ -42,8 +82,8 @@ FusedDilatedConvNormFunc
 
 A custom ``torch.autograd.Function`` that fuses the 3-tap dilated
 depthwise convolution and per-example layer normalization. User code
-interacts with it through :func:`fused_dilated_conv_norm` and
-:class:`CheriBlock`.
+interacts with it through :func:`fused_dilated_conv_norm`,
+:class:`FusedDilatedConvNorm` and :class:`CheriBlock`.
 
 
 Forward kernels

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -97,9 +97,18 @@ In code:
 .. code-block:: python
 
    def forward(self, X):
-       X_conv = fused_dilated_conv_norm(X, self.conv_weight, self.dilation)
+       X_conv = self.conv(X)
        X_mlp = self.linear2(self.activation(self.linear1(X_conv)))
        return X + X_mlp * self.residual_scale
+
+``self.conv`` is a :class:`~cherimoya.cheri.FusedDilatedConvNorm`, a thin
+``nn.Module`` around :func:`~cherimoya.cheri.fused_dilated_conv_norm` that
+exists so attribution methods walking the module tree have a node to hook.
+The depthwise weight lives on it, at ``block.conv.conv_weight``;
+``block.conv_weight`` remains as a read-only alias. Note that the
+inference megakernel calls the fused op directly rather than through the
+submodule, so a hook on ``block.conv`` fires on the CPU and training
+paths but **not** under ``no_grad`` on CUDA.
 
 The conv weight has shape ``(3, C)``; the linear weights have shapes
 ``(expansion * C, C)`` and ``(C, expansion * C)``. None of the layers in
@@ -176,7 +185,10 @@ to Muon iff ``ndim == 2 and "weight" in name and name != "linear.weight"
 and "conv_weight" not in name``. The name-based exclusions peel off
 the count head and the per-block ``conv_weight`` (the latter lives on
 the depth-wise dilated path, not a projection matmul, so AdamW handles
-it). Separately, ``lw0`` and ``lw1`` are routed to SGD by exact name
+it). That last test is a substring rather than an exact match, which is
+what keeps it matching now that the parameter is named
+``blocks.N.conv.conv_weight`` in ``named_parameters()``. Separately,
+``lw0`` and ``lw1`` are routed to SGD by exact name
 match. Any 2D projection weight inside a custom block will go to Muon
 automatically. Override this in your own training script if you want
 different routing.

--- a/docs/tutorials/save_load.rst
+++ b/docs/tutorials/save_load.rst
@@ -29,6 +29,35 @@ megakernel) is intentionally not part of the state dict and is not
 saved. It is rebuilt on the next forward pass.
 
 
+State dict keys are frozen
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+One key does not match the module tree, deliberately. Each block's
+depthwise convolution weight is the parameter
+``blocks.N.conv.conv_weight`` — it lives on the ``conv`` submodule — but
+it is written to and read from the state dict as ``blocks.N.conv_weight``,
+in that position, which is where it has always been:
+
+.. code-block:: python
+
+   >>> [n for n, _ in model.named_parameters() if 'conv_weight' in n][:1]
+   ['blocks.0.conv.conv_weight']
+   >>> [k for k in model.state_dict() if 'conv_weight' in k][:1]
+   ['blocks.0.conv_weight']
+
+The on-disk format is a compatibility surface shared with every
+already-trained checkpoint and with any installed version of the package,
+so it is held fixed while the module tree is free to change. A
+``state_dict`` post-hook renames on the way out and
+``CheriBlock._load_from_state_dict`` accepts either spelling on the way
+in, so checkpoints move in both directions between versions.
+
+Write ``block.conv.conv_weight`` when you need the parameter itself.
+``block.conv_weight`` still reads it — the same object, not a copy — but
+is read-only; assigning through it raises rather than leaving the
+submodule holding the old tensor.
+
+
 Loading
 -------
 

--- a/tests/test_cheri.py
+++ b/tests/test_cheri.py
@@ -170,7 +170,7 @@ def test_cheri_block_residual_scale_controls_output(residual_scale):
 	else:
 		# Recompute MLP path explicitly.
 		from cherimoya.cheri import fused_dilated_conv_norm
-		x_conv = fused_dilated_conv_norm(x, block.conv_weight, block.dilation)
+		x_conv = fused_dilated_conv_norm(x, block.conv.conv_weight, block.dilation)
 		x_mlp = block.linear2(block.activation(block.linear1(x_conv)))
 		expected = x + x_mlp * residual_scale
 		assert torch.allclose(y, expected, atol=1e-6)
@@ -521,8 +521,8 @@ def test_cheri_block_triton_backward_matches_cpu_autograd():
 	assert torch.allclose(cpu_block.linear2.weight.grad,
 		gpu_block.linear2.weight.grad.cpu(), atol=1e-3, rtol=1e-3), \
 		"linear2 grad diverged"
-	assert torch.allclose(cpu_block.conv_weight.grad,
-		gpu_block.conv_weight.grad.cpu(), atol=1e-3, rtol=1e-3), \
+	assert torch.allclose(cpu_block.conv.conv_weight.grad,
+		gpu_block.conv.conv_weight.grad.cpu(), atol=1e-3, rtol=1e-3), \
 		"conv_weight grad diverged"
 	# x.grad goes through both the Triton bwd and the linear bwds.
 	assert torch.allclose(x_cpu.grad, x_gpu.grad.cpu(),

--- a/tests/test_cheri.py
+++ b/tests/test_cheri.py
@@ -731,6 +731,36 @@ def test_cheri_block_forward_uses_the_fused_submodule():
 	assert calls[0] == x.shape
 
 
+@pytest.mark.cuda
+@pytest.mark.triton
+def test_fused_submodule_hook_skipped_by_inference_path_cuda():
+	"""Document the one place the submodule is bypassed.
+
+	The megakernel calls the fused op directly instead of going through
+	``self.conv``, so a hook on the submodule does not fire under
+	``no_grad`` on CUDA. Attribution is unaffected — DeepLIFT needs
+	gradients and so takes the training path, which is asserted here
+	alongside — but anyone hooking the block to capture activations at
+	inference would otherwise get silence and no explanation."""
+
+	block = CheriBlock(n_filters=16, dilation=2).cuda().eval()
+	x = torch.randn(2, 64, 16, device='cuda')
+
+	calls = []
+	block.conv.register_forward_hook(lambda mod, inp, out: calls.append(1))
+
+	with torch.no_grad():
+		assert block._can_use_inference_path(x), \
+			"megakernel did not dispatch; this test proves nothing"
+		block(x)
+
+	assert calls == [], "megakernel unexpectedly routed through self.conv"
+
+	# Gradients enabled -> training path -> the hook fires as documented.
+	block(x)
+	assert len(calls) == 1, f"training path hook fired {len(calls)} times"
+
+
 # --------- Checkpoint compatibility (conv_weight <-> conv.conv_weight) ----
 
 def _submodule_format(state_dict):

--- a/tests/test_cheri.py
+++ b/tests/test_cheri.py
@@ -742,7 +742,7 @@ def _submodule_format(state_dict):
 
 	renamed = {}
 	for key, value in state_dict.items():
-		if key.endswith('conv_weight') and not key.endswith('.conv.conv_weight'):
+		if key.endswith('conv_weight') and not key.endswith('conv.conv_weight'):
 			key = key[:-len('conv_weight')] + 'conv.conv_weight'
 		renamed[key] = value
 
@@ -980,7 +980,9 @@ def test_cheri_block_init_matches_legacy_rng_order():
 	torch.manual_seed(0)
 	block = CheriBlock(n_filters=8, dilation=1, expansion=2)
 
-	assert_array_almost_equal(block.conv_weight.detach().numpy(), [
+	# Read through the submodule, not the `conv_weight` alias, so this
+	# test fails only on an RNG-order change and not on the alias.
+	assert_array_almost_equal(block.conv.conv_weight.detach().numpy(), [
 		[-0.031542,  0.007219, -0.027066, -0.004142, -0.004975, -0.024640,
 		  0.012513, -0.024463],
 		[-0.002585, -0.001092,  0.008167,  0.022527,  0.038701,  0.020154,

--- a/tests/test_cheri.py
+++ b/tests/test_cheri.py
@@ -5,6 +5,7 @@ import torch
 
 from cherimoya.cheri import (
 	CheriBlock,
+	FusedDilatedConvNorm,
 	HAS_TRITON,
 	_cheri_conv_norm_cpu,
 	fused_dilated_conv_norm,
@@ -624,3 +625,233 @@ def test_cheri_block_small_hidden_no_grad_matches_grad_cuda(n_filters, expansion
 
 	diff = (y_grad - y_nograd).abs().max().item()
 	assert diff <= 1e-4, f"fallback path diverged: diff={diff}"
+
+
+# --------- FusedDilatedConvNorm module wrapper -----------------------------
+
+def test_fused_module_matches_raw_function():
+	"""The wrapper must add module dispatch and nothing else — the
+	output has to be bit-identical to calling the function directly."""
+
+	torch.manual_seed(0)
+	mod = FusedDilatedConvNorm(n_filters=8, dilation=2)
+	x = torch.randn(2, 64, 8)
+
+	y_mod = mod(x)
+	y_fn = fused_dilated_conv_norm(x, mod.conv_weight, mod.dilation)
+
+	assert torch.equal(y_mod, y_fn), \
+		f"wrapper diverged; diff={(y_mod - y_fn).abs().max().item()}"
+
+
+def test_fused_module_registers_conv_weight_as_parameter():
+	"""The depthwise weight must remain a trainable Parameter after
+	moving onto the submodule, with its original (3, C) shape."""
+
+	mod = FusedDilatedConvNorm(n_filters=16, dilation=1)
+
+	assert isinstance(mod.conv_weight, torch.nn.Parameter)
+	assert mod.conv_weight.shape == (3, 16)
+	assert mod.conv_weight.requires_grad
+	assert [n for n, _ in mod.named_parameters()] == ['conv_weight']
+
+
+def test_fused_module_rejects_wrong_rank_and_channels():
+	"""The asserts in `forward` should catch mis-shaped inputs rather
+	than letting them reach the kernel."""
+
+	mod = FusedDilatedConvNorm(n_filters=8, dilation=1)
+
+	with pytest.raises(AssertionError):
+		mod(torch.randn(64, 8))          # missing the batch dim
+
+	with pytest.raises(AssertionError):
+		mod(torch.randn(2, 64, 4))       # channel dim != n_filters
+
+
+def test_fused_module_is_differentiable():
+	"""Gradients must flow to both the input and the conv weight —
+	the wrapper must not detach anything."""
+
+	mod = FusedDilatedConvNorm(n_filters=8, dilation=2)
+	x = torch.randn(2, 32, 8, requires_grad=True)
+
+	mod(x).sum().backward()
+
+	assert x.grad is not None and torch.isfinite(x.grad).all()
+	assert mod.conv_weight.grad is not None
+	assert torch.isfinite(mod.conv_weight.grad).all()
+
+
+def test_cheri_block_exposes_fused_module_as_child():
+	"""DeepLIFT finds hook targets by walking `named_modules`. If the
+	fused op is not a registered child of the block, an attribution run
+	silently falls back to plain autograd for that op."""
+
+	block = CheriBlock(n_filters=16, dilation=2)
+
+	assert isinstance(block.conv, FusedDilatedConvNorm)
+
+	found = [m for m in block.modules()
+		if isinstance(m, FusedDilatedConvNorm)]
+	assert len(found) == 1, "expected exactly one fused node in the tree"
+
+	# It must be reachable under the documented name, since the state
+	# dict migration below keys off `conv.conv_weight`.
+	assert dict(block.named_modules())['conv'] is block.conv
+
+
+def test_cheri_block_conv_weight_registered_under_submodule():
+	"""The block's state dict must expose the weight at its new path."""
+
+	block = CheriBlock(n_filters=16, dilation=2)
+	keys = block.state_dict().keys()
+
+	assert 'conv.conv_weight' in keys
+	assert 'conv_weight' not in keys
+
+
+def test_cheri_block_forward_uses_the_fused_submodule():
+	"""A hook on `block.conv` must actually fire during the grad-enabled
+	forward. This is precisely what DeepLIFT relies on."""
+
+	block = CheriBlock(n_filters=16, dilation=2)
+	x = torch.randn(2, 64, 16)
+
+	calls = []
+	block.conv.register_forward_hook(
+		lambda mod, inp, out: calls.append(out.shape))
+
+	block(x)
+
+	assert len(calls) == 1, f"fused submodule hook fired {len(calls)} times"
+	assert calls[0] == x.shape
+
+
+# --------- Checkpoint migration (conv_weight -> conv.conv_weight) ---------
+
+def test_cheri_block_loads_legacy_checkpoint():
+	"""Checkpoints written before the wrapper existed hold the weight at
+	`conv_weight`. `_load_from_state_dict` must transparently migrate it
+	to `conv.conv_weight` so old models stay loadable."""
+
+	torch.manual_seed(0)
+	block = CheriBlock(n_filters=16, dilation=2)
+
+	# Build a legacy-format state dict by renaming the key back.
+	legacy = block.state_dict()
+	legacy['conv_weight'] = legacy.pop('conv.conv_weight')
+
+	torch.manual_seed(1)
+	fresh = CheriBlock(n_filters=16, dilation=2)
+	fresh.load_state_dict(legacy)
+
+	assert torch.equal(fresh.conv.conv_weight, block.conv.conv_weight)
+
+
+def test_legacy_checkpoint_load_reproduces_original_output():
+	"""End-to-end check on the migration: a block restored from a legacy
+	checkpoint must produce the same output as the block that wrote it."""
+
+	torch.manual_seed(0)
+	block = CheriBlock(n_filters=16, dilation=2)
+	x = torch.randn(2, 64, 16)
+	y_expected = block(x)
+
+	legacy = block.state_dict()
+	legacy['conv_weight'] = legacy.pop('conv.conv_weight')
+
+	torch.manual_seed(1)
+	restored = CheriBlock(n_filters=16, dilation=2)
+	# The renamed key would be "unexpected" without the migration hook.
+	restored.load_state_dict(legacy)
+
+	assert torch.allclose(restored(x), y_expected, atol=1e-6)
+
+
+def test_current_format_checkpoint_still_loads():
+	"""The migration must not disturb the normal path — a state dict
+	already using the new key loads unchanged."""
+
+	torch.manual_seed(0)
+	block_a = CheriBlock(n_filters=16, dilation=2)
+	torch.manual_seed(1)
+	block_b = CheriBlock(n_filters=16, dilation=2)
+
+	block_a.load_state_dict(block_b.state_dict())
+
+	assert torch.equal(block_a.conv.conv_weight, block_b.conv.conv_weight)
+
+
+def test_new_key_wins_when_both_keys_present():
+	"""If a state dict somehow carries both keys, the current one must
+	take precedence and the legacy one must not clobber it."""
+
+	torch.manual_seed(0)
+	block = CheriBlock(n_filters=16, dilation=2)
+
+	sd = block.state_dict()
+	sd['conv_weight'] = torch.zeros_like(sd['conv.conv_weight'])
+
+	fresh = CheriBlock(n_filters=16, dilation=2)
+	# The stray legacy key is unexpected; ignore it rather than error.
+	fresh.load_state_dict(sd, strict=False)
+
+	assert torch.equal(fresh.conv.conv_weight, block.conv.conv_weight)
+	assert not torch.allclose(fresh.conv.conv_weight,
+		torch.zeros_like(fresh.conv.conv_weight))
+
+
+def test_legacy_checkpoint_migrates_for_nested_blocks():
+	"""The hook keys off `prefix`, so it must work when the block is
+	nested inside a parent module rather than loaded standalone."""
+
+	torch.manual_seed(0)
+	parent = torch.nn.Sequential(
+		CheriBlock(n_filters=8, dilation=1),
+		CheriBlock(n_filters=8, dilation=2),
+	)
+
+	legacy = parent.state_dict()
+	for i in range(2):
+		legacy[f'{i}.conv_weight'] = legacy.pop(f'{i}.conv.conv_weight')
+
+	torch.manual_seed(1)
+	fresh = torch.nn.Sequential(
+		CheriBlock(n_filters=8, dilation=1),
+		CheriBlock(n_filters=8, dilation=2),
+	)
+	fresh.load_state_dict(legacy)
+
+	for i in range(2):
+		assert torch.equal(fresh[i].conv.conv_weight,
+			parent[i].conv.conv_weight), f"block {i} did not migrate"
+
+
+@pytest.mark.cuda
+@pytest.mark.triton
+def test_inference_path_reads_migrated_conv_weight_cuda():
+	"""The no_grad fused path reaches for `self.conv.conv_weight`
+	directly. Verify it picks up a weight installed via a legacy
+	checkpoint, so migration and the fast path agree."""
+
+	torch.manual_seed(0)
+	block = CheriBlock(n_filters=16, dilation=2).cuda()
+	x = torch.randn(2, 64, 16, device='cuda')
+
+	legacy = {k: v.clone() for k, v in block.state_dict().items()}
+	legacy['conv_weight'] = legacy.pop('conv.conv_weight')
+
+	torch.manual_seed(1)
+	restored = CheriBlock(n_filters=16, dilation=2).cuda()
+	restored.load_state_dict(legacy)
+	restored.eval()
+
+	with torch.no_grad():
+		y_restored = restored(x)
+	block.eval()
+	with torch.no_grad():
+		y_expected = block(x)
+
+	diff = (y_restored - y_expected).abs().max().item()
+	assert diff <= 1e-4, f"inference path saw a stale weight: diff={diff}"

--- a/tests/test_cheri.py
+++ b/tests/test_cheri.py
@@ -3,6 +3,8 @@
 import pytest
 import torch
 
+from numpy.testing import assert_array_almost_equal
+
 from cherimoya.cheri import (
 	CheriBlock,
 	FusedDilatedConvNorm,
@@ -702,13 +704,14 @@ def test_cheri_block_exposes_fused_module_as_child():
 
 
 def test_cheri_block_conv_weight_registered_under_submodule():
-	"""The block's state dict must expose the weight at its new path."""
+	"""The live parameter must sit on the submodule, even though the
+	serialized form keeps the historical name."""
 
 	block = CheriBlock(n_filters=16, dilation=2)
-	keys = block.state_dict().keys()
+	names = [n for n, _ in block.named_parameters()]
 
-	assert 'conv.conv_weight' in keys
-	assert 'conv_weight' not in keys
+	assert 'conv.conv_weight' in names
+	assert 'conv_weight' not in names
 
 
 def test_cheri_block_forward_uses_the_fused_submodule():
@@ -728,19 +731,70 @@ def test_cheri_block_forward_uses_the_fused_submodule():
 	assert calls[0] == x.shape
 
 
-# --------- Checkpoint migration (conv_weight -> conv.conv_weight) ---------
+# --------- Checkpoint compatibility (conv_weight <-> conv.conv_weight) ----
+
+def _submodule_format(state_dict):
+	"""Re-key a saved state dict onto the live submodule path.
+
+	`state_dict` deliberately emits the historical `conv_weight`; this
+	produces what a naive `nn.Module` would have written instead, which
+	is the other format `_load_from_state_dict` has to accept."""
+
+	renamed = {}
+	for key, value in state_dict.items():
+		if key.endswith('conv_weight') and not key.endswith('.conv.conv_weight'):
+			key = key[:-len('conv_weight')] + 'conv.conv_weight'
+		renamed[key] = value
+
+	return renamed
+
+
+def test_cheri_block_state_dict_uses_legacy_key():
+	"""The on-disk format is frozen. A checkpoint written today must key
+	the depthwise weight exactly as every previously trained model does,
+	so older installs of the package can still read it."""
+
+	block = CheriBlock(n_filters=16, dilation=2)
+	keys = block.state_dict().keys()
+
+	assert 'conv_weight' in keys
+	assert 'conv.conv_weight' not in keys
+
+
+def test_cheri_block_state_dict_key_order_unchanged():
+	"""The renaming hook must leave the key in its original position, not
+	move it to the end of the dict."""
+
+	block = CheriBlock(n_filters=16, dilation=2)
+
+	assert list(block.state_dict().keys()) == [
+		'conv_weight', 'linear1.weight', 'linear2.weight']
+
+
+def test_cheri_block_state_dict_key_order_unchanged_when_nested():
+	"""Same guarantee once blocks are children of a parent module — the
+	hook rebuilds the shared destination dict, so it must not disturb
+	keys written by earlier siblings."""
+
+	parent = torch.nn.Sequential(
+		CheriBlock(n_filters=8, dilation=1),
+		CheriBlock(n_filters=8, dilation=2),
+	)
+
+	assert list(parent.state_dict().keys()) == [
+		'0.conv_weight', '0.linear1.weight', '0.linear2.weight',
+		'1.conv_weight', '1.linear1.weight', '1.linear2.weight']
+
 
 def test_cheri_block_loads_legacy_checkpoint():
 	"""Checkpoints written before the wrapper existed hold the weight at
-	`conv_weight`. `_load_from_state_dict` must transparently migrate it
-	to `conv.conv_weight` so old models stay loadable."""
+	`conv_weight`. `_load_from_state_dict` must route it onto the
+	submodule so old models stay loadable."""
 
 	torch.manual_seed(0)
 	block = CheriBlock(n_filters=16, dilation=2)
-
-	# Build a legacy-format state dict by renaming the key back.
 	legacy = block.state_dict()
-	legacy['conv_weight'] = legacy.pop('conv.conv_weight')
+	assert 'conv_weight' in legacy
 
 	torch.manual_seed(1)
 	fresh = CheriBlock(n_filters=16, dilation=2)
@@ -750,47 +804,47 @@ def test_cheri_block_loads_legacy_checkpoint():
 
 
 def test_legacy_checkpoint_load_reproduces_original_output():
-	"""End-to-end check on the migration: a block restored from a legacy
-	checkpoint must produce the same output as the block that wrote it."""
+	"""End-to-end check: a block restored from a legacy checkpoint must
+	produce the same output as the block that wrote it."""
 
 	torch.manual_seed(0)
 	block = CheriBlock(n_filters=16, dilation=2)
 	x = torch.randn(2, 64, 16)
 	y_expected = block(x)
 
-	legacy = block.state_dict()
-	legacy['conv_weight'] = legacy.pop('conv.conv_weight')
-
 	torch.manual_seed(1)
 	restored = CheriBlock(n_filters=16, dilation=2)
-	# The renamed key would be "unexpected" without the migration hook.
-	restored.load_state_dict(legacy)
+	restored.load_state_dict(block.state_dict())
 
 	assert torch.allclose(restored(x), y_expected, atol=1e-6)
 
 
-def test_current_format_checkpoint_still_loads():
-	"""The migration must not disturb the normal path — a state dict
-	already using the new key loads unchanged."""
+def test_submodule_format_checkpoint_also_loads():
+	"""A state dict keyed on the submodule path — what a bare
+	`named_parameters` walk or a hand-built dict produces — must load
+	too, so the block accepts both spellings."""
 
 	torch.manual_seed(0)
 	block_a = CheriBlock(n_filters=16, dilation=2)
 	torch.manual_seed(1)
 	block_b = CheriBlock(n_filters=16, dilation=2)
 
-	block_a.load_state_dict(block_b.state_dict())
+	new_format = _submodule_format(block_b.state_dict())
+	assert 'conv.conv_weight' in new_format
+
+	block_a.load_state_dict(new_format)
 
 	assert torch.equal(block_a.conv.conv_weight, block_b.conv.conv_weight)
 
 
 def test_new_key_wins_when_both_keys_present():
-	"""If a state dict somehow carries both keys, the current one must
-	take precedence and the legacy one must not clobber it."""
+	"""If a state dict somehow carries both spellings, the submodule key
+	must take precedence and the legacy one must not clobber it."""
 
 	torch.manual_seed(0)
 	block = CheriBlock(n_filters=16, dilation=2)
 
-	sd = block.state_dict()
+	sd = _submodule_format(block.state_dict())
 	sd['conv_weight'] = torch.zeros_like(sd['conv.conv_weight'])
 
 	fresh = CheriBlock(n_filters=16, dilation=2)
@@ -803,7 +857,7 @@ def test_new_key_wins_when_both_keys_present():
 
 
 def test_legacy_checkpoint_migrates_for_nested_blocks():
-	"""The hook keys off `prefix`, so it must work when the block is
+	"""The hooks key off `prefix`, so they must work when the block is
 	nested inside a parent module rather than loaded standalone."""
 
 	torch.manual_seed(0)
@@ -813,8 +867,7 @@ def test_legacy_checkpoint_migrates_for_nested_blocks():
 	)
 
 	legacy = parent.state_dict()
-	for i in range(2):
-		legacy[f'{i}.conv_weight'] = legacy.pop(f'{i}.conv.conv_weight')
+	assert {'0.conv_weight', '1.conv_weight'} <= set(legacy)
 
 	torch.manual_seed(1)
 	fresh = torch.nn.Sequential(
@@ -826,6 +879,39 @@ def test_legacy_checkpoint_migrates_for_nested_blocks():
 	for i in range(2):
 		assert torch.equal(fresh[i].conv.conv_weight,
 			parent[i].conv.conv_weight), f"block {i} did not migrate"
+
+	# ...and the submodule spelling round-trips through nesting as well.
+	torch.manual_seed(2)
+	fresh2 = torch.nn.Sequential(
+		CheriBlock(n_filters=8, dilation=1),
+		CheriBlock(n_filters=8, dilation=2),
+	)
+	fresh2.load_state_dict(_submodule_format(legacy))
+
+	for i in range(2):
+		assert torch.equal(fresh2[i].conv.conv_weight,
+			parent[i].conv.conv_weight), f"block {i} did not load"
+
+
+def test_cheri_block_state_dict_round_trips_through_save(tmp_path):
+	"""`torch.save`/`torch.load` of a block state dict must survive with
+	the legacy key intact, since that is how checkpoints reach disk."""
+
+	torch.manual_seed(0)
+	block = CheriBlock(n_filters=16, dilation=2)
+
+	path = tmp_path / "block.torch"
+	torch.save(block.state_dict(), path)
+	loaded = torch.load(path, weights_only=True)
+
+	assert list(loaded.keys()) == [
+		'conv_weight', 'linear1.weight', 'linear2.weight']
+
+	torch.manual_seed(1)
+	fresh = CheriBlock(n_filters=16, dilation=2)
+	fresh.load_state_dict(loaded)
+
+	assert torch.equal(fresh.conv.conv_weight, block.conv.conv_weight)
 
 
 @pytest.mark.cuda
@@ -840,7 +926,7 @@ def test_inference_path_reads_migrated_conv_weight_cuda():
 	x = torch.randn(2, 64, 16, device='cuda')
 
 	legacy = {k: v.clone() for k, v in block.state_dict().items()}
-	legacy['conv_weight'] = legacy.pop('conv.conv_weight')
+	assert 'conv_weight' in legacy
 
 	torch.manual_seed(1)
 	restored = CheriBlock(n_filters=16, dilation=2).cuda()
@@ -855,3 +941,58 @@ def test_inference_path_reads_migrated_conv_weight_cuda():
 
 	diff = (y_restored - y_expected).abs().max().item()
 	assert diff <= 1e-4, f"inference path saw a stale weight: diff={diff}"
+
+
+# --------- conv_weight alias and initialization order --------------------
+
+def test_cheri_block_conv_weight_alias_reads_submodule():
+	"""`block.conv_weight` was public API before the refactor. It must
+	still resolve, and to the same object rather than a copy."""
+
+	block = CheriBlock(n_filters=16, dilation=2)
+
+	assert block.conv_weight is block.conv.conv_weight
+	assert isinstance(block.conv_weight, torch.nn.Parameter)
+
+	# The alias must not add a second registered parameter.
+	assert [n for n, _ in block.named_parameters()] == [
+		'conv.conv_weight', 'linear1.weight', 'linear2.weight']
+
+
+def test_cheri_block_conv_weight_alias_is_read_only():
+	"""Assigning through the alias would leave the submodule holding the
+	old parameter, so it must fail loudly rather than silently diverge."""
+
+	block = CheriBlock(n_filters=16, dilation=2)
+	original = block.conv.conv_weight
+
+	with pytest.raises((AttributeError, KeyError)):
+		block.conv_weight = torch.nn.Parameter(torch.zeros(3, 16))
+
+	assert block.conv.conv_weight is original
+
+
+def test_cheri_block_init_matches_legacy_rng_order():
+	"""Initialization must draw from the RNG in the same order as it did
+	before `conv_weight` moved onto a submodule, so a given seed rebuilds
+	the same block. Values recorded from v0.2.1."""
+
+	torch.manual_seed(0)
+	block = CheriBlock(n_filters=8, dilation=1, expansion=2)
+
+	assert_array_almost_equal(block.conv_weight.detach().numpy(), [
+		[-0.031542,  0.007219, -0.027066, -0.004142, -0.004975, -0.024640,
+		  0.012513, -0.024463],
+		[-0.002585, -0.001092,  0.008167,  0.022527,  0.038701,  0.020154,
+		  0.020093, -0.008670],
+		[-0.024852,  0.025691,  0.004875,  0.010607, -0.000291, -0.044714,
+		  0.029321, -0.024381]], 4)
+
+	assert_array_almost_equal(block.linear1.weight.detach().numpy()[0], [
+		 0.012885,  0.078600, -0.002488,  0.005907,  0.007653, -0.010994,
+		-0.019881,  0.026919], 4)
+
+	assert_array_almost_equal(block.linear2.weight.detach().numpy()[0], [
+		 0.006855, -0.032090, -0.011746,  0.012008,  0.008756, -0.001929,
+		 0.006605, -0.003750, -0.028541,  0.011851, -0.023164,  0.000715,
+		 0.004320, -0.018322,  0.031197, -0.063074], 4)

--- a/tests/test_fit_wiring.py
+++ b/tests/test_fit_wiring.py
@@ -176,3 +176,143 @@ def test_fit_does_not_flatten_signals_for_downstream_evaluate(tmp_path):
 	assert captured.get('signals') == original_signals, (
 		"fit flattened the structured signals form before PeakGenerator: "
 		"got {!r}".format(captured.get('signals')))
+
+
+# --------- optimizer routing ---------------------------------------------
+#
+# These import `_split_parameters` from the fit command rather than
+# restating the rule, so an edit to the routing logic is caught here
+# instead of silently diverging from a copy.
+
+def _routing(model):
+	"""Return (name -> buckets) plus the raw lists, for readable asserts."""
+
+	from cherimoya_cli.commands.fit import _split_parameters
+
+	muon, adam, lw = _split_parameters(model)
+	by_id = {}
+	for bucket, params in (('muon', muon), ('adam', adam), ('lw', lw)):
+		for p in params:
+			by_id.setdefault(id(p), []).append(bucket)
+
+	names = {}
+	for name, p in model.named_parameters():
+		names[name] = by_id.get(id(p), [])
+
+	return names, muon, adam, lw
+
+
+@pytest.fixture
+def routed_model():
+	import torch
+	from cherimoya import Cherimoya
+
+	torch.manual_seed(0)
+	return Cherimoya(n_filters=16, n_layers=3, signal_groups=[1, 2],
+		n_control_tracks=2, verbose=False)
+
+
+def test_fit_routes_projection_weights_to_muon(routed_model):
+	"""The MLP projections inside each block are what Muon is for."""
+
+	names, muon, adam, lw = _routing(routed_model)
+
+	projections = [n for n in names
+		if n.endswith('linear1.weight') or n.endswith('linear2.weight')]
+	assert len(projections) == 6, "expected 2 projections per block"
+
+	for name in projections:
+		assert names[name] == ['muon'], f"{name} -> {names[name]}"
+
+
+def test_fit_routes_depthwise_conv_weight_to_adamw(routed_model):
+	"""``conv_weight`` is 2D and matches "weight", so it would land in
+	Muon without the explicit exclusion. It sits on the depth-wise path
+	rather than being a projection matmul, so it belongs in AdamW. The
+	exclusion is a substring test, which is what lets it keep working
+	now that the parameter lives on the ``conv`` submodule."""
+
+	names, muon, adam, lw = _routing(routed_model)
+
+	conv = [n for n in names if n.endswith('conv_weight')]
+	assert len(conv) == 3, f"expected one per block, got {conv}"
+
+	for name in conv:
+		assert names[name] == ['adam'], f"{name} -> {names[name]}"
+
+
+def test_fit_routes_loss_balancing_weights_to_sgd(routed_model):
+	"""lw0/lw1 are matched by exact name, not by shape."""
+
+	names, muon, adam, lw = _routing(routed_model)
+
+	assert names.get('lw0') == ['lw']
+	assert names.get('lw1') == ['lw']
+	assert len(lw) == 2
+
+
+def test_fit_routes_output_head_to_adamw(routed_model):
+	"""``linear.weight`` is the output head and is excluded by exact
+	name, so it must not be swept into Muon with the projections."""
+
+	names, _, _, _ = _routing(routed_model)
+
+	assert names['linear.weight'] == ['adam']
+
+
+def test_fit_assigns_every_parameter_exactly_once(routed_model):
+	"""The three buckets must partition the parameters -- no parameter
+	trained by two optimizers, and none left untrained."""
+
+	names, muon, adam, lw = _routing(routed_model)
+
+	duplicated = {n: b for n, b in names.items() if len(b) > 1}
+	assert not duplicated, f"parameters in more than one optimizer: {duplicated}"
+
+	unrouted = [n for n, b in names.items() if not b]
+	assert not unrouted, f"parameters in no optimizer: {unrouted}"
+
+	total = len(muon) + len(adam) + len(lw)
+	assert total == len(names), f"{total} routed vs {len(names)} parameters"
+
+
+def test_fit_routing_has_no_duplicate_parameter_objects(routed_model):
+	"""Guards against a parameter being registered twice on the model
+	(e.g. an alias accidentally re-registering it), which would hand the
+	same tensor to an optimizer twice and double its updates."""
+
+	import torch
+
+	model = routed_model
+	names, muon, adam, lw = _routing(model)
+
+	for bucket, params in (('muon', muon), ('adam', adam), ('lw', lw)):
+		ids = [id(p) for p in params]
+		assert len(ids) == len(set(ids)), f"{bucket} lists a parameter twice"
+
+	# remove_duplicate=False exposes any tensor reachable under two names.
+	all_named = list(model.named_parameters(remove_duplicate=False))
+	assert len(all_named) == len(list(model.named_parameters()))
+
+	# ...and each optimizer must accept its bucket without complaint.
+	for params in (muon, adam, lw):
+		torch.optim.AdamW(params)
+
+
+def test_fit_routing_is_stable_without_control_tracks():
+	"""Routing must not depend on the control-track configuration."""
+
+	import torch
+	from cherimoya import Cherimoya
+
+	torch.manual_seed(0)
+	model = Cherimoya(n_filters=16, n_layers=3, signal_groups=[1],
+		n_control_tracks=0, verbose=False)
+	names, muon, adam, lw = _routing(model)
+
+	assert not [n for n, b in names.items() if len(b) != 1]
+	for name in names:
+		if name.endswith('linear1.weight') or name.endswith('linear2.weight'):
+			assert names[name] == ['muon'], f"{name} -> {names[name]}"
+		elif name.endswith('conv_weight'):
+			assert names[name] == ['adam'], f"{name} -> {names[name]}"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -233,18 +233,12 @@ def test_grouped_model_fit_smoke(tmp_path):
 	training_data = torch.utils.data.DataLoader(sampler, batch_size=4,
 		num_workers=0)
 
-	# Optimizers — split params the same way fit.py does: 2D projection
-	# weights to Muon, Kendall lw0/lw1 to SGD, everything else (incl.
-	# conv_weight and the head) to AdamW.
-	muon_params, adam_params, lw_params = [], [], []
-	for name, p in model.named_parameters():
-		if name in ("lw0", "lw1"):
-			lw_params.append(p)
-		elif (p.ndim == 2 and "weight" in name and name != "linear.weight"
-				and "conv_weight" not in name):
-			muon_params.append(p)
-		else:
-			adam_params.append(p)
+	# Optimizers — route params using the same helper `cherimoya fit`
+	# uses, rather than restating the rule, so this smoke test exercises
+	# the real routing instead of a copy that could drift from it.
+	from cherimoya_cli.commands.fit import _split_parameters
+
+	muon_params, adam_params, lw_params = _split_parameters(model)
 	muon_opt = Muon(muon_params, lr=1e-3, weight_decay=0.0)
 	adam_opt = torch.optim.AdamW(adam_params, lr=1e-3, weight_decay=0.0)
 	lw_opt = torch.optim.SGD(lw_params, lr=1e-3, weight_decay=0.0,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 from cherimoya import Cherimoya
+from cherimoya.cherimoya import _Log
 
 
 @pytest.fixture
@@ -713,3 +714,88 @@ def test_model_no_grad_stable_across_repeated_calls_cuda():
 	assert torch.equal(c1, c2)
 	assert torch.equal(p1, p3)
 	assert torch.equal(c1, c3)
+
+
+# --------- _Log module wrapper --------------------------------------------
+
+def test_log_module_matches_torch_log():
+	"""The wrapper must be a pure pass-through to `torch.log`."""
+
+	log = _Log()
+	x = torch.rand(4, 8) + 0.1  # strictly positive; log is undefined at <= 0
+
+	assert torch.equal(log(x), torch.log(x))
+
+
+def test_log_module_has_no_parameters():
+	"""A pure op wrapper must not introduce trainable state."""
+
+	assert list(_Log().parameters()) == []
+
+
+def test_model_registers_log_module():
+	"""DeepLIFT locates hook targets by walking `named_modules`, so the
+	log has to be a registered child of the model."""
+
+	model = Cherimoya(n_filters=8, n_layers=2, signal_groups=[1],
+		n_control_tracks=2, verbose=False)
+
+	assert isinstance(model._log, _Log)
+	assert dict(model.named_modules())['_log'] is model._log
+
+
+def test_model_forward_uses_log_module_with_control_tracks():
+	"""A hook on `model._log` must fire during the forward when control
+	tracks are present — this is the path DeepLIFT needs to intercept."""
+
+	model = Cherimoya(n_filters=8, n_layers=2, signal_groups=[1],
+		n_control_tracks=2, verbose=False).eval()
+	L = _input_window_for(model)
+	X = torch.randn(1, 4, L)
+	X_ctl = torch.rand(1, 2, L)
+
+	calls = []
+	model._log.register_forward_hook(
+		lambda mod, inp, out: calls.append(out))
+
+	model(X, X_ctl)
+
+	assert len(calls) == 1, f"_Log hook fired {len(calls)} times"
+	assert torch.isfinite(calls[0]).all()
+
+
+def test_model_log_module_unused_without_control_tracks():
+	"""With no control tracks there is nothing to log, so the module
+	must stay out of the graph rather than run on a dummy input."""
+
+	model = Cherimoya(n_filters=8, n_layers=2, signal_groups=[1],
+		n_control_tracks=0, verbose=False).eval()
+	L = _input_window_for(model)
+
+	calls = []
+	model._log.register_forward_hook(
+		lambda mod, inp, out: calls.append(out))
+
+	model(torch.randn(1, 4, L))
+
+	assert calls == []
+
+
+def test_model_log_module_output_matches_inline_log():
+	"""End-to-end guard that routing through the module did not change
+	the counts head: recompute the expected log term directly."""
+
+	model = Cherimoya(n_filters=8, n_layers=2, signal_groups=[1],
+		n_control_tracks=2, verbose=False).eval()
+	L = _input_window_for(model)
+	X = torch.randn(1, 4, L)
+	X_ctl = torch.rand(1, 2, L)
+
+	captured = []
+	model._log.register_forward_hook(
+		lambda mod, inp, out: captured.append((inp[0], out)))
+
+	model(X, X_ctl)
+
+	x_in, y_out = captured[0]
+	assert torch.equal(y_out, torch.log(x_in))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -426,6 +426,56 @@ def test_save_payload_format(tmp_path, small_model_kwargs):
 	assert payload['config']['n_filters'] == small_model_kwargs['n_filters']
 
 
+def test_saved_checkpoint_uses_legacy_conv_weight_keys(tmp_path,
+	small_model_kwargs):
+	"""The on-disk key set is a compatibility surface shared with every
+	previously trained checkpoint and with installed versions of the
+	package, so it is frozen even though the parameter has moved onto
+	the ``conv`` submodule. `test_cheri.py` pins this for a lone block;
+	this pins it for the artifact `save` actually writes."""
+
+	model = Cherimoya(**small_model_kwargs)
+	path = tmp_path / "model.torch"
+	model.save(str(path))
+
+	state_dict = torch.load(str(path), weights_only=True,
+		map_location='cpu')['state_dict']
+
+	conv_keys = [k for k in state_dict if 'conv_weight' in k]
+	assert conv_keys == ['blocks.{}.conv_weight'.format(i)
+		for i in range(model.n_layers)]
+
+	# The live parameter is the one that moved; the two spellings must
+	# not both appear, or an older install would see an unexpected key.
+	assert [n for n, _ in model.named_parameters() if 'conv_weight' in n] == [
+		'blocks.{}.conv.conv_weight'.format(i) for i in range(model.n_layers)]
+
+
+def test_saved_checkpoint_reloads_without_mutating_the_payload(tmp_path,
+	small_model_kwargs):
+	"""`CheriBlock._load_from_state_dict` re-keys entries as it loads.
+	It must do that to a copy: a caller holding the payload — to load it
+	into a second model, or to inspect it afterwards — must not find its
+	dict rewritten underneath it."""
+
+	model = Cherimoya(**small_model_kwargs)
+	path = tmp_path / "model.torch"
+	model.save(str(path))
+	payload = torch.load(str(path), weights_only=True, map_location='cpu')
+
+	keys_before = list(payload['state_dict'].keys())
+
+	fresh = Cherimoya(**small_model_kwargs)
+	fresh.load_state_dict(payload['state_dict'])
+	assert list(payload['state_dict'].keys()) == keys_before
+
+	# The second load is the point: it must see the same legacy keys.
+	again = Cherimoya(**small_model_kwargs)
+	again.load_state_dict(payload['state_dict'])
+	assert torch.equal(again.blocks[0].conv.conv_weight,
+		model.blocks[0].conv.conv_weight)
+
+
 def test_load_to_specified_device(tmp_path, small_model_kwargs, device):
 	model = Cherimoya(**small_model_kwargs)
 	path = tmp_path / "model.torch"


### PR DESCRIPTION
DeepLIFT is an attribution method that works by registering forward/backward hooks for `torch.nn.Module`’s. These hooks enable hijacking the vanilla PyTorch computation graph to compute DeepLIFT multipliers for each module and multiply them across modules (chain rule) to compute the contributions from the inputs to the final outputs.

On Triton-enabled platforms, the `CheriBlock` class uses a custom fused kernel which is currently implemented as a function (`fused_dilated_conv_norm`). This change wraps it in a `torch.nn.Module` so that we can register DeepLIFT handlers for it. 

The change also introduces a migration path for older checkpoints that did not use this module on the `CheriBlock` class.