### PR TITLE
DOC declare FusedDilatedConvNorm public and _Log private

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -25,6 +25,13 @@ Attribution
   do not mention these two classes behave exactly as they did before —
   the nodes exist to be opted into, and adding them changes no existing
   result.
+* Of the two, only ``FusedDilatedConvNorm`` is public — import it from
+  ``cherimoya.cheri``. Registering a rule for it means naming the class,
+  so its name and import path are a compatibility surface and are treated
+  as one. ``_Log`` stays private: it wraps a single elementwise
+  ``torch.log``, which the standard DeepLIFT rescale rule already handles,
+  so there is no reason for caller code to name that type. See
+  :doc:`development` for the full public/private split.
 
 Compatibility
 ~~~~~~~~~~~~~

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -53,21 +53,41 @@ Explicitly:
 
 * **Public** symbols, re-exported from ``cherimoya.__init__``:
   :class:`~cherimoya.Cherimoya`, :class:`~cherimoya.CheriBlock`,
-  :class:`~cherimoya.cherimoya.EMA`.
+  :class:`~cherimoya.cherimoya.EMA`, and the four model wrappers
+  :class:`~cherimoya.wrappers.ControlWrapper`,
+  :class:`~cherimoya.wrappers.ProfileWrapper`,
+  :class:`~cherimoya.wrappers.LogCountWrapper` and
+  :class:`~cherimoya.wrappers.ExpectedCountsWrapper`.
 * **Public** module-level symbols:
   :func:`~cherimoya.io.PeakGenerator`,
   :class:`~cherimoya.io.PeakNegativeSampler`,
   :func:`~cherimoya.cheri.fused_dilated_conv_norm`,
+  :class:`~cherimoya.cheri.FusedDilatedConvNorm`,
   :class:`~cherimoya.cheri.FusedDilatedConvNormFunc`,
   :func:`~cherimoya.performance.calculate_performance_measures` and
   its component metrics, :func:`~cherimoya.losses._mixture_loss`
   (despite the underscore — it is the trainer's loss function and
   the API is stable).
+
+  :class:`~cherimoya.cheri.FusedDilatedConvNorm` is public because
+  naming the class *is* the interface: an attribution method that wants
+  to treat the fused convolution specially has to identify it by type,
+  so the name and import path are a compatibility surface even though
+  nothing in this package calls the class from outside
+  :class:`~cherimoya.CheriBlock`.
 * **Private** and may change: anything else, including the Triton
   kernels (``_fwd_*``, ``_bwd_*``, ``_fwd_inf_*``), the CPU fallback
   (``_cheri_conv_norm_cpu``), the CheriBlock weight cache
-  (``_w_cache``), and the model's checkpoint-payload helper
-  (``_init_kwargs``).
+  (``_w_cache``), the ``torch.log`` module wrapper in the count head
+  (``cherimoya.cherimoya._Log``), and the model's checkpoint-payload
+  helper (``_init_kwargs``).
+
+  ``_Log`` is deliberately *not* public, unlike its counterpart above.
+  It exists for the same reason — giving attribution methods a node in
+  the module tree — but it wraps a single elementwise call to
+  ``torch.log``, which the standard DeepLIFT rescale rule already
+  handles correctly. There is no reason for caller code to name the
+  type, so it stays private and may be renamed or removed.
 
 
 Development install


### PR DESCRIPTION
Follow-up to #34. That PR added two `nn.Module` nodes so attribution methods walking the module tree have something to hook, but left the public/private question open. This settles it in `development.rst`.

**`cherimoya.cheri.FusedDilatedConvNorm` is public.** Registering a DeepLIFT rule for the fused convolution means identifying it by type, so the class name and import path are a compatibility surface whether or not that is written down — even though nothing inside the package calls it from outside `CheriBlock`. It already had an API entry; now the public/private list agrees.

**`cherimoya.cherimoya._Log` stays private.** It exists for the same reason, but wraps a single elementwise `torch.log`, which the standard DeepLIFT rescale rule already handles correctly. No caller needs to name that type, so it remains free to be renamed or removed. The private list now says so explicitly rather than leaving it unmentioned.

**Also, slightly beyond the stated scope:** the re-export bullet in the same list was stale. It named `Cherimoya`, `CheriBlock` and `EMA`, but `cherimoya/__init__.py` also exports `ControlWrapper`, `ProfileWrapper`, `LogCountWrapper` and `ExpectedCountsWrapper`. Since docs accuracy is a hard rule here and this is the exact list being edited, they are added — flagging it rather than folding it in silently.

Docs only; no code changes.

## Checks

- `pytest` — 299 passed (GPU visible, so the CUDA and Triton tests ran rather than skipping)
- `sphinx-build -W` — clean
- Confirmed the new `:class:` references resolve to links in the built HTML rather than degrading to plain text, since nitpicky mode is off and an unresolved reference would not fail the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)