### PR TITLE
REMOVE the _Log module wrapper from the count head

### DIFF
--- a/cherimoya/cherimoya.py
+++ b/cherimoya/cherimoya.py
@@ -23,21 +23,6 @@ from bpnetlite.logging import Logger
 torch.set_float32_matmul_precision('high')
 
 
-class _Log(torch.nn.Module):
-	"""A module wrapper around ``torch.log``.
-
-	Owning the log as a module (rather than calling ``torch.log`` inline)
-	gives attribution methods that walk the module tree, such as DeepLIFT,
-	a concrete node to register a non-linear op against.
-	"""
-
-	def __init__(self):
-		super(_Log, self).__init__()
-
-	def forward(self, X):
-		return torch.log(X)
-
-
 class EMA:
 	"""Exponential moving average of a model's parameters.
 
@@ -202,7 +187,6 @@ class Cherimoya(torch.nn.Module):
 
 		self.lw0 = torch.nn.Parameter(torch.ones(self.n_groups))
 		self.lw1 = torch.nn.Parameter(torch.ones(self.n_groups))
-		self._log = _Log()
 
 		torch.nn.init.trunc_normal_(self.iconv.weight, std=0.02)
 		torch.nn.init.trunc_normal_(self.fconv.weight, std=0.02)
@@ -404,7 +388,13 @@ class Cherimoya(torch.nn.Module):
 		if X_ctl is not None:
 			X_ctl = torch.sum(X_ctl[:, :, start:end].float(), dim=(1, 2))
 			X_ctl = X_ctl.unsqueeze(-1)
-			X = torch.cat([X, self._log(X_ctl+1)], dim=-1)
+			# Called inline rather than through an nn.Module. A module here
+			# would give DeepLIFT a node to hook, but it would have nothing
+			# to do: this input depends only on the control tracks, which
+			# attribution holds fixed between a sequence and its references,
+			# so the difference across the node is exactly zero and the
+			# rescale rule has no multiplier to correct.
+			X = torch.cat([X, torch.log(X_ctl+1)], dim=-1)
 
 		y_counts = self.linear(X)
 		return y_profile, y_counts

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -8,30 +8,33 @@ Attribution
 ~~~~~~~~~~~
 
 * The fused dilated convolution + per-example norm inside
-  :class:`cherimoya.CheriBlock` now lives on a ``FusedDilatedConvNorm``
-  submodule (``block.conv``), and the control-track log inside
-  :class:`cherimoya.Cherimoya` on a ``_Log`` submodule, rather than being
-  called inline. Attribution methods that walk the module tree — DeepLIFT
-  and SHAP in particular — now have concrete nodes to hook, which is a
-  prerequisite for correct DeepLIFT support. The kernels, the conditions
-  under which each forward path dispatches, and the numerics are all
-  unchanged.
+  :class:`cherimoya.CheriBlock` now lives on a
+  :class:`~cherimoya.cheri.FusedDilatedConvNorm` submodule
+  (``block.conv``) rather than being called inline. Attribution methods
+  that walk the module tree — DeepLIFT and SHAP in particular — now have
+  a concrete node to hook, which is a prerequisite for correct DeepLIFT
+  support. The kernel, the conditions under which each forward path
+  dispatches, and the numerics are all unchanged. The class is public;
+  import it from ``cherimoya.cheri``, since registering a rule for it
+  means naming the type.
 * Note that the inference megakernel calls the fused op directly rather
   than through ``block.conv``, so hooks on that submodule fire on the CPU
   and Triton training paths but not under ``no_grad`` on CUDA.
   Attribution is unaffected, since it runs with gradients enabled.
-* Nothing is registered against the new nodes by default. An attribution
+* Nothing is registered against the new node by default. An attribution
   method only acts on a module it has been given a rule for, so runs that
-  do not mention these two classes behave exactly as they did before —
-  the nodes exist to be opted into, and adding them changes no existing
-  result.
-* Of the two, only ``FusedDilatedConvNorm`` is public — import it from
-  ``cherimoya.cheri``. Registering a rule for it means naming the class,
-  so its name and import path are a compatibility surface and are treated
-  as one. ``_Log`` stays private: it wraps a single elementwise
-  ``torch.log``, which the standard DeepLIFT rescale rule already handles,
-  so there is no reason for caller code to name that type. See
-  :doc:`development` for the full public/private split.
+  do not mention the class behave exactly as they did before — the node
+  exists to be opted into, and adding it changes no existing result.
+* **The count head's control-track log stays an inline** ``torch.log``.
+  An earlier revision of this work wrapped it in a module for symmetry
+  with the convolution, and that module has been removed again: it could
+  not affect an attribution. That log's input is the summed control
+  tracks, which attribution holds fixed between a sequence and its
+  references, so the difference across the node is exactly zero and the
+  rescale rule has no multiplier to correct — registering a rule for it
+  was measured to leave attributions bitwise identical. It would only
+  become a useful hook point for attributions taken with respect to the
+  control tracks themselves, which is not a supported path.
 
 Compatibility
 ~~~~~~~~~~~~~
@@ -48,7 +51,7 @@ Compatibility
 * The parameter's *name* does change even though its checkpoint key does
   not. ``named_parameters()`` now reports ``blocks.N.conv.conv_weight``
   where it reported ``blocks.N.conv_weight``, and the module tree gains a
-  ``blocks.N.conv`` node per block plus a model-level ``_log``. Code that
+  ``blocks.N.conv`` node per block. Code that
   matches parameter names by substring is unaffected — including the
   Muon / AdamW / SGD split in ``cherimoya fit``, whose ``conv_weight``
   exclusion is a substring test and still routes every parameter to the

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -75,19 +75,16 @@ Explicitly:
   so the name and import path are a compatibility surface even though
   nothing in this package calls the class from outside
   :class:`~cherimoya.CheriBlock`.
+  The count head's control-track log has no counterpart class. It is a
+  plain ``torch.log`` call, deliberately: its input is the summed control
+  tracks, which attribution holds fixed between a sequence and its
+  references, so a module there would be a hook point with nothing to
+  correct.
 * **Private** and may change: anything else, including the Triton
   kernels (``_fwd_*``, ``_bwd_*``, ``_fwd_inf_*``), the CPU fallback
   (``_cheri_conv_norm_cpu``), the CheriBlock weight cache
-  (``_w_cache``), the ``torch.log`` module wrapper in the count head
-  (``cherimoya.cherimoya._Log``), and the model's checkpoint-payload
-  helper (``_init_kwargs``).
-
-  ``_Log`` is deliberately *not* public, unlike its counterpart above.
-  It exists for the same reason — giving attribution methods a node in
-  the module tree — but it wraps a single elementwise call to
-  ``torch.log``, which the standard DeepLIFT rescale rule already
-  handles correctly. There is no reason for caller code to name the
-  type, so it stays private and may be renamed or removed.
+  (``_w_cache``), and the model's checkpoint-payload helper
+  (``_init_kwargs``).
 
 
 Development install

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -6,7 +6,6 @@ import pytest
 import torch
 
 from cherimoya import Cherimoya
-from cherimoya.cherimoya import _Log
 
 
 @pytest.fixture
@@ -760,86 +759,63 @@ def test_model_no_grad_stable_across_repeated_calls_cuda():
 	assert torch.equal(c1, c3)
 
 
-# --------- _Log module wrapper --------------------------------------------
+# --------- control-track term in the count head ---------------------------
 
-def test_log_module_matches_torch_log():
-	"""The wrapper must be a pure pass-through to `torch.log`."""
+def test_counts_head_control_term_is_log_of_summed_controls():
+	"""The count head takes ``log(sum(controls) + 1)`` as one extra input.
 
-	log = _Log()
-	x = torch.rand(4, 8) + 0.1  # strictly positive; log is undefined at <= 0
+	Asserted on the arithmetic rather than by hooking a module, so it holds
+	however that log happens to be spelled. The count path takes control
+	tracks *only* through this term -- the trunk features come from the
+	sequence alone -- so holding the sequence fixed and changing only the
+	controls isolates it: the whole change in the prediction has to be the
+	last column of the head's weight times the change in the log term."""
 
-	assert torch.equal(log(x), torch.log(x))
-
-
-def test_log_module_has_no_parameters():
-	"""A pure op wrapper must not introduce trainable state."""
-
-	assert list(_Log().parameters()) == []
-
-
-def test_model_registers_log_module():
-	"""DeepLIFT locates hook targets by walking `named_modules`, so the
-	log has to be a registered child of the model."""
-
-	model = Cherimoya(n_filters=8, n_layers=2, signal_groups=[1],
-		n_control_tracks=2, verbose=False)
-
-	assert isinstance(model._log, _Log)
-	assert dict(model.named_modules())['_log'] is model._log
-
-
-def test_model_forward_uses_log_module_with_control_tracks():
-	"""A hook on `model._log` must fire during the forward when control
-	tracks are present — this is the path DeepLIFT needs to intercept."""
-
+	torch.manual_seed(0)
 	model = Cherimoya(n_filters=8, n_layers=2, signal_groups=[1],
 		n_control_tracks=2, verbose=False).eval()
 	L = _input_window_for(model)
 	X = torch.randn(1, 4, L)
-	X_ctl = torch.rand(1, 2, L)
 
-	calls = []
-	model._log.register_forward_hook(
-		lambda mod, inp, out: calls.append(out))
+	ctl_a = torch.rand(1, 2, L)
+	ctl_b = torch.rand(1, 2, L) * 7.0     # a different total, same shape
 
-	model(X, X_ctl)
+	with torch.no_grad():
+		_, counts_a = model(X, ctl_a)
+		_, counts_b = model(X, ctl_b)
 
-	assert len(calls) == 1, f"_Log hook fired {len(calls)} times"
-	assert torch.isfinite(calls[0]).all()
+	# Controls are summed over the trimmed window only, so the untrimmed
+	# flanks must not contribute.
+	start, end = model.trimming, L - model.trimming
+	sums = [c[:, :, start:end].float().sum() for c in (ctl_a, ctl_b)]
+	delta_term = torch.log(sums[1] + 1) - torch.log(sums[0] + 1)
 
+	expected = model.linear.weight[:, -1] * delta_term
+	observed = (counts_b - counts_a)[0]
 
-def test_model_log_module_unused_without_control_tracks():
-	"""With no control tracks there is nothing to log, so the module
-	must stay out of the graph rather than run on a dummy input."""
-
-	model = Cherimoya(n_filters=8, n_layers=2, signal_groups=[1],
-		n_control_tracks=0, verbose=False).eval()
-	L = _input_window_for(model)
-
-	calls = []
-	model._log.register_forward_hook(
-		lambda mod, inp, out: calls.append(out))
-
-	model(torch.randn(1, 4, L))
-
-	assert calls == []
+	assert torch.allclose(observed, expected, atol=1e-5), (
+		"count head's control term is not log(sum + 1): "
+		"expected {}, got {}".format(expected.tolist(), observed.tolist()))
 
 
-def test_model_log_module_output_matches_inline_log():
-	"""End-to-end guard that routing through the module did not change
-	the counts head: recompute the expected log term directly."""
+def test_counts_head_ignores_controls_outside_the_trimmed_window():
+	"""Signal in the untrimmed flanks must not reach the count head, which
+	is what makes the sum above a sum over ``[trimming, L - trimming)``."""
 
+	torch.manual_seed(0)
 	model = Cherimoya(n_filters=8, n_layers=2, signal_groups=[1],
 		n_control_tracks=2, verbose=False).eval()
 	L = _input_window_for(model)
 	X = torch.randn(1, 4, L)
-	X_ctl = torch.rand(1, 2, L)
 
-	captured = []
-	model._log.register_forward_hook(
-		lambda mod, inp, out: captured.append((inp[0], out)))
+	ctl = torch.zeros(1, 2, L)
+	ctl[:, :, model.trimming:L - model.trimming] = 0.5
 
-	model(X, X_ctl)
+	flanked = ctl.clone()
+	flanked[:, :, :model.trimming] = 99.0      # only outside the window
 
-	x_in, y_out = captured[0]
-	assert torch.equal(y_out, torch.log(x_in))
+	with torch.no_grad():
+		_, counts = model(X, ctl)
+		_, counts_flanked = model(X, flanked)
+
+	assert torch.equal(counts, counts_flanked)


### PR DESCRIPTION
Follow-up to #34 and #37. `_Log` was added so DeepLIFT would have a node to hook on the count head's control-track log. It can't affect an attribution, so it comes back out and the call goes back to a plain `torch.log`.

## Why it can't matter

The log's input is the summed control tracks (`cherimoya.py`, count-head branch) — it never sees the sequence. Attribution holds the control track fixed between a sequence and its shuffled references, so `delta_in` across that node is exactly zero and the rescale rule has no multiplier to correct. Plain autograd already gives the right answer for that branch, which is "contributes nothing."

Measured rather than argued:

- Instrumented a `deep_lift_shap` run and compared the node's input between the observed and reference halves of the batch: **max |observed − reference| = 0.000e+00**.
- Ran attributions with and without `additional_nonlinear_ops={_Log: _nonlinear}`: **bitwise identical, r = 1.000000, max abs difference 0**, no NaN/inf.

With `ControlWrapper`, which synthesizes zero control tracks, the branch is `log(0+1) = 0` — a dead constant.

It would become a genuine hook point for attributions taken with respect to the control tracks themselves. That is not a supported path today, and the module can come back if it becomes one.

`FusedDilatedConvNorm` is untouched — that node is load-bearing, since the fused convolution is neither elementwise nor free of sequence dependence.

## Tests

The six tests `_Log` carried all probed the module (is it registered, does a hook fire, is it a pass-through) rather than the behaviour, so they went with it. They are replaced by two that pin what the count head actually depends on, and that hold however the log is spelled:

- `test_counts_head_control_term_is_log_of_summed_controls` — holds the sequence fixed, varies only the controls, and asserts the entire change in the prediction equals the head's last weight column times the change in `log(sum + 1)`. This pins the functional form end to end.
- `test_counts_head_ignores_controls_outside_the_trimmed_window` — puts signal in the untrimmed flanks and asserts the counts are unchanged, which is what makes the sum above a sum over `[trimming, L - trimming)`.

Net 299 → 295 tests, with the control-track branch better covered than before: nothing previously asserted the `log(sum + 1)` form itself.

## Docs

- `CHANGELOG.rst` — the Attribution entries described a module that will not ship, so they now describe the shipping state, plus a bullet recording that the log is deliberately inline and why. Also dropped the stale "module tree gains ... a model-level `_log`" clause from the Compatibility entry.
- `development.rst` — removed the `_Log` private-list entry added in #37, replaced by a note under the public list explaining why the log has no counterpart class.
- Swept the rest of the tree for references to `_Log`, the module tree, and the count head: none stale. The remaining `log` mentions in `architecture.rst` are the loss (`log1pMSE`, the log-squared regularizer) and unrelated.

## Checks

- `pytest` — 295 passed, GPU visible so CUDA and Triton tests ran
- `sphinx-build -W` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)