### PR TITLE
ADD gitignore entry for the local compatibility sweep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ docs/_build/
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+# Local compatibility sweep (see compat/README.md)
+compat/


### PR DESCRIPTION
One line of `.gitignore`. No code changes.

`compat/` is a pre-merge harness that compares two commits for checkpoint and behavioural compatibility across the trained model zoo — checkpoint round-trip in both directions, the fold-0 and published-atlas load sweeps, predictions, DeepLIFT, ISM, variant effect, gradients, optimizer routing, design, CLI defaults, and throughput. It depends on this machine's model paths and takes minutes to hours, so it is neither packaged nor committed.

That matches how the repo already treats heavy local tooling: `bench_kernels.py` is gitignored and documented in `development.rst`, and its ignore line lives in this same file.

Committing the rule rather than leaving it in a local working tree does two things:

- keeps `compat/` out of `git status` for anyone who builds one, instead of leaving a permanent uncommitted diff
- stops a stray `git add .` from pulling several hundred megabytes of `.npz` dumps into history

## Checks

- `git ls-files compat/` is empty, so nothing under it is tracked and the rule is effective
- Confirmed new files created under `compat/` are ignored immediately
- No other file is touched by this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)